### PR TITLE
Moved mapserver variables to config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# geomoose specific
+demo/config.js
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/demo/config.js.example
+++ b/demo/config.js.example
@@ -1,0 +1,4 @@
+CONFIG = {
+    mapserver_url: '/mapserver/cgi-bin/mapserv',
+    mapfile_root: '/data/'
+};

--- a/demo/index.html
+++ b/demo/index.html
@@ -57,7 +57,7 @@
         <span id="coordinate-display"></span>
     </div>
 
-    <script type="text/javascript" src="globals.js"></script>
+    <script type="text/javascript" src="config.js"></script>
     <script type="text/javascript" src="../dist/ol.js"></script>
     <script type="text/javascript" src="../dist/geomoose.min.js"></script>
     <script type="text/javascript" src="../dist/services/identify.js"></script>

--- a/demo/test.html
+++ b/demo/test.html
@@ -62,7 +62,7 @@
         <span id="coordinate-display"></span>
     </div>
 
-    <script type="text/javascript" src="globals.js"></script>
+    <script type="text/javascript" src="config.js"></script>
     <script type="text/javascript" src="/node_modules/openlayers/dist/ol.js"></script>
     <script type="text/javascript" src="/dist/geomoose.js"></script>
     <script type="text/javascript" src="/src/services/identify.js"></script>

--- a/demo/test.js
+++ b/demo/test.js
@@ -30,8 +30,8 @@
 
 
 var app = new gm3.Application({
-    mapserver_url: '/mapserver/cgi-bin/mapserv',
-    mapfile_root: '/data/'
+    mapserver_url: CONFIG.mapserver_url,
+    mapfile_root: CONFIG.mapfile_root
 });
 
 app.uiUpdate = function(ui) {
@@ -60,9 +60,9 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     //  if so, use Bing as the geocoder otherwise the application
     //  will show a "can't find the service" message.
     // BING_KEY should be set in globals.js
-    if(typeof(BING_KEY) !== 'undefined') {
+    if(typeof(CONFIG.bing_key) !== 'undefined') {
         app.registerService('geocode', BingGeocoder, {
-            key: BING_KEY
+            key: CONFIG.bing_key 
         });
     }
 


### PR DESCRIPTION
The mighty return of `config.js`, now makes it
easier to adapt to different environments without changing the
code.

1. Moves the mapserver and mapfile root  out of test.js.
2. Adds an ignore for config.js to prevent it from being added to the repo.
3. Changed BING_KEY to use CONFIG.bing_key.