### PR TITLE
Adjust gruntfile for Less modifications

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,10 @@ module.exports = function(grunt) {
                     spawn: false,
                 }
             },
+            less: {
+                files: ['src/less/**/*'],
+                tasks: ['less:build']
+            },
             services: {
                 files: ['src/services/*'],
                 tasks: ['copy:services']

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -153,7 +153,7 @@ module.exports = function(grunt) {
 
     grunt.task.registerTask('lint', ['eslint']);
 
-    grunt.task.registerTask('serve', ['webpack-dev-server:start', 'watch:gm3', 'watch:services']);
+    grunt.task.registerTask('serve', ['webpack-dev-server:start', 'watch']);
 
     // only build the non-minified version.
     grunt.task.registerTask('build-dev', ['eslint', 'copy:services', 'webpack:build-dev']);


### PR DESCRIPTION
Two changes:

1. Add a `watch` subtask for Less modifications
1. Currently, the `serve` task calls the two `watch` subtasks, `watch:gm3` and `watch:services`. Grunt begins running `watch:gm3`, but the watch tasks never finishes, and therefore `watch:services` never runs. 
This problem is solved by running the `watch` group as a whole. This will allow all three watch subtasks: `watch:gm3`, `watch:services`, and `watch:less` to be run concurrently upon running `serve`


