### PR TITLE
Updated Toolbar Styling 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Listing your name below is an agreement to contribute your work product to the G
 ## Contributors (in alphabetical order)
 
 * [Dan "Ducky" Little](https://github.com/theduckylittle)
+* [Caitlin Wolters](https://github.com/CaitW)

--- a/demo/test.css
+++ b/demo/test.css
@@ -53,22 +53,6 @@ body {
     height: 75px;
 }
 
-#toolbar {
-    height: 25px;
-}
-
-#toolbar button {
-    border: none;
-    background: none;
-    text-decoration: underline;
-    color: steelblue;
-    padding: 2px;
-    font-size: 10px;
-    margin: 2px;
-    cursor: pointer;
-}
-
-
 #tabs {
     bottom: 20px;
     border-top: solid 1px black;

--- a/demo/test.css
+++ b/demo/test.css
@@ -53,6 +53,10 @@ body {
     height: 75px;
 }
 
+#header img {
+    display: inline;
+}
+
 #tabs {
     bottom: 20px;
     border-top: solid 1px black;

--- a/src/gm3/components/toolbar.jsx
+++ b/src/gm3/components/toolbar.jsx
@@ -58,7 +58,7 @@ class Toolbar extends Component {
         };
 
         return (
-            <button onClick={tool_click} key={tool.name}>
+            <button onClick={tool_click} key={tool.name} className={"tool tool-" + tool.name}>
                 <span className="icon"></span><span className="label">{tool.label}</span>
             </button>
         );

--- a/src/less/gm3.less
+++ b/src/less/gm3.less
@@ -29,6 +29,7 @@
 @import 'serviceForms.less';
 @import 'results.less';
 @import 'coordinates.less';
+@import 'toolbar.less';
 
 .hide {
     display: none;

--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -1,0 +1,104 @@
+#header {
+	img {
+		// Override display:inline's tendency to create mysterious spacing issues around images
+		display: block;
+	}
+}
+
+#toolbar {
+	margin-top: 3px;
+	height: 22px;
+	border: 0 solid #000;
+	border-top-width: 1px;
+	button.tool {
+		height: 22px;
+		padding: 0 7px;
+		font-size: 14px;
+		border: 0 solid rgba(0,0,0,0.1);
+		background: none;
+		&:not(:last-child) {
+			border-right-width: 1px;
+		}
+		&:hover {
+			cursor: pointer;
+			text-decoration: underline;
+		}	
+	}
+}
+
+.tool .icon {
+	margin-right: 5px;
+	display: none;
+}
+
+.tool-fullextent {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-arrows-alt;
+		}
+	}
+}
+
+.tool-measure {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-arrows-h;
+		}
+	}
+}
+
+.tool-print {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-print;
+		}
+	}
+}
+
+.tool-identify {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-info-circle;
+		}
+	}
+}
+
+.tool-geocode {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-globe;
+		}
+	}
+}
+
+.tool-select {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-mouse-pointer;
+		}
+	}
+}
+
+.tool-search {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-search;
+		}
+	}
+}
+
+.tool-findme {
+	.icon {
+		.fa; 
+		&:before {
+			content: @fa-var-location-arrow;
+		}
+	}
+}

--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -1,104 +1,88 @@
-#header {
-	img {
-		// Override display:inline's tendency to create mysterious spacing issues around images
-		display: block;
-	}
-}
-
-#toolbar {
-	margin-top: 3px;
-	height: 22px;
-	border: 0 solid #000;
-	border-top-width: 1px;
-	button.tool {
-		height: 22px;
-		padding: 0 7px;
-		font-size: 14px;
-		border: 0 solid rgba(0,0,0,0.1);
-		background: none;
-		&:not(:last-child) {
-			border-right-width: 1px;
-		}
-		&:hover {
-			cursor: pointer;
-			text-decoration: underline;
-		}	
-	}
+button.tool {
+    height: 22px;
+    padding: 0 7px;
+    font-size: 14px;
+    border: none;
+    background: none;
+    &:hover {
+        cursor: pointer;
+        text-decoration: underline;
+    }
 }
 
 .tool .icon {
-	margin-right: 5px;
-	display: none;
+    margin-right: 5px;
+    display: none;
 }
 
 .tool-fullextent {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-arrows-alt;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-arrows-alt;
+        }
+    }
 }
 
 .tool-measure {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-arrows-h;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-arrows-h;
+        }
+    }
 }
 
 .tool-print {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-print;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-print;
+        }
+    }
 }
 
 .tool-identify {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-info-circle;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-info-circle;
+        }
+    }
 }
 
 .tool-geocode {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-globe;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-globe;
+        }
+    }
 }
 
 .tool-select {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-mouse-pointer;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-mouse-pointer;
+        }
+    }
 }
 
 .tool-search {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-search;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-search;
+        }
+    }
 }
 
 .tool-findme {
-	.icon {
-		.fa; 
-		&:before {
-			content: @fa-var-location-arrow;
-		}
-	}
+    .icon {
+        .fa;
+        &:before {
+            content: @fa-var-location-arrow;
+        }
+    }
 }


### PR DESCRIPTION
<img width="910" alt="screen shot 2017-04-25 at 11 10 03 am" src="https://cloud.githubusercontent.com/assets/8647176/25392837/c2ed0d38-29a7-11e7-9dd6-a7cd73d60d60.png">

Additional styling suggestions welcome.

* The new style is constrained slightly by the fixed height of the header (75px, and therefore toolbar: 25px). 
* The buttons have hover affordances (underlines, pointer-cursors) to indicate their selectability.
* Individual icons are specified via CSS 
* Having to specify individual icons in the CSS is messy:
```less
.tool-measure {
    .icon {
        .fa; // extend font-awesome to include generic icon styles
            &:before {
                content: @fa-var-arrows-h; // specify particular icon to be used 
            }
        }
    }
}
```
