### PR TITLE
Fixed path issue with tests on windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "http://www.geomoose.org",
   "bugs": "https://github.com/geomoose/gm3/issues",
   "scripts": {
-    "test": "node node_modules/jest/bin/jest.js --coverage ./tests/",
+    "test": "node node_modules/jest/bin/jest.js --coverage tests",
     "prepublish": "grunt build",
     "start": "grunt serve",
     "serve": "grunt serve"


### PR DESCRIPTION
`./tests/` wasn't a valid path on windows.  Dropping the relative paths fixes that.