### PR TITLE
Change name of version component to Version

### DIFF
--- a/src/gm3/components/version.jsx
+++ b/src/gm3/components/version.jsx
@@ -29,7 +29,7 @@ import React, {Component, PropTypes } from 'react';
 
 import * as util from '../util';
 
-export default class Toolbar extends Component {
+export default class Version extends Component {
 
     render() {
         return (


### PR DESCRIPTION
Although it didn't affect anything, the "version" component class was named "Toolbar". 