### PR TITLE
Fix for broken WMS legend graphics.

### DIFF
--- a/src/gm3/components/layers/wms.js
+++ b/src/gm3/components/layers/wms.js
@@ -101,6 +101,7 @@ export function getLegend(mapSource, mapView, layerName) {
         'VERSION': '1.1.0',
         'WIDTH': '250',
         'LAYER': layerName,
+        'FORMAT': 'image/png',
     }, mapSource.params);
 
     const images = [];


### PR DESCRIPTION
Forgot to set the default FORMAT parameter. That was causing the legend to
not generate.  Defaults to PNG, this can be overriden in the map source
definition.