### PR TITLE
Specify coordinate projection

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -1,4 +1,4 @@
-/** Demo test application.  
+/** Demo test application.
  *
  *  WARNING! ACHTUNG! THIS IS FOR DEVELOPMENT PURPOSES ONLY!!!
  *
@@ -83,7 +83,21 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     app.add(gm3.components.Grid, 'results-grid');
     app.add(gm3.components.Version, 'version');
     app.add(gm3.components.CoordinateDisplay, 'coordinate-display', {
-        usng: true, latLon: true
+        projections:  [
+            {
+                label: 'X,Y',
+                ref: 'xy'
+            },
+            {
+                label: 'USNG',
+                ref: 'usng'
+            },
+            {
+                label: 'Lat,Lon',
+                ref: 'EPSG:4326',
+                precision: 3
+            }
+        ]
     });
 
 
@@ -92,10 +106,10 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     var print_preview = app.add(gm3.components.PrintModal, 'print-preview', {});
     app.registerAction('print', function() {
         this.run = function() {
-           print_preview.setState({open: true}); 
+           print_preview.setState({open: true});
         }
     }, {});
-            
+
 
     tracker.startTracking();
     hash_tracker.startTracking();

--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -57,6 +57,11 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     tracker.restore();
     hash_tracker.restore();
 
+    app.addProjection({
+        ref: 'EPSG:26915',
+        def: '+proj=utm +zone=15 +ellps=GRS80 +datum=NAD83 +units=m +no_defs'
+    });
+
     app.registerService('identify', IdentifyService);
     app.registerService('search', SearchService);
     app.registerService('select', SelectService, {

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -516,6 +516,16 @@ class Application {
         this.store.dispatch(mapActions.setView(view));
     }
 
+    /**
+     * addProjection
+     * - A function that can be called by the user to add a custom projection.
+     * - Facade for adding a projection to the proj4 registry, which then allows its use
+     *     when calling the proj4 or OpenLayers libraries.
+     *
+     * @param {Object} projDef - an object containing an ID and a definition for a projection
+     * @param {string} projDef.ref - a string ID that will be used to refer to defined projection
+     * @param {string} projDef.def - a string definition of the projection, in WKT/Proj format
+     */
     addProjection(projDef) {
         util.addProjDef(proj4, projDef.ref, projDef.def);
     }

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -53,6 +53,7 @@ import Modal from './components/modal';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import proj4 from 'proj4';
 
 import { getLayerFromPath, getQueryableLayers, getActiveMapSources } from './actions/mapSource';
 
@@ -513,6 +514,10 @@ class Application {
      */
     setView(view) {
         this.store.dispatch(mapActions.setView(view));
+    }
+
+    addProjection(projDef) {
+        util.addProjDef(proj4, projDef.ref, projDef.def);
     }
 
 };

--- a/src/gm3/components/coordinates.jsx
+++ b/src/gm3/components/coordinates.jsx
@@ -31,6 +31,32 @@ import { addProjDef } from '../util.js';
 
 import proj from 'ol/proj';
 
+/**
+ * CoordinateDisplay options
+ * - These options can be passed when adding the coordinate display to the app
+ *
+ * @param {Object[]} projections - an array of projections
+ * @param {string} projections[].label - The label appearing next to displayed coordinates
+ * @param {string} projections[].ref - an ID referring to the projection being used
+ * @param {number} projections[].precision - integer referring to the number of decimal places
+ *     to display for this projection
+ *
+ * Named Projections (do not need to be defined by the user):
+ *     - USNG
+ *        ref: 'usng'
+ *     - XY
+ *        ref: 'xy'
+ *
+ * Predefined Projections
+ *     - Lat/Lng
+ *        ref: 'EPSG:4326'
+ *     - Web Mercator
+ *        ref: 'EPSG:3857'
+ *
+ * Default Projections - displayed when user fails to configure component
+ *     - XY, Lat/Lng, USNG
+ */
+
 class CoordinateDisplay extends Component {
 
     constructor(props) {

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -458,6 +458,13 @@ export function configureProjections(p4) {
 
 }
 
+/**
+ * Add Proj projection defs
+ */
+export function addProjDef(p4, code, def) {
+    p4.defs(code, def);
+}
+
 /* Determine the UTM zone for a point
  *
  * @param {Point-like} An array containing [x,y] in WGS84 or NAD83 DD

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -459,7 +459,12 @@ export function configureProjections(p4) {
 }
 
 /**
- * Add Proj projection defs
+ * addProjDef
+ * Add a projection definition
+ *
+ * @param {object} p4 - the proj4js library
+ * @param {string} code - an ID used to refer to the defined projection
+ * @param {string} def - a proj4/wkt string used to define a projection
  */
 export function addProjDef(p4, code, def) {
     p4.defs(code, def);


### PR DESCRIPTION
This is still a bit of a work in progress. Questions/comments:

1. I didn't add a coordinate transform property (yet) in favor of proj/wkt strings

```Javascript
{
    label: 'UTM15',
    ref: 'EPSG:26915',
    // pretty
    projDef: '+proj=utm +zone=15 +ellps=GRS80 +datum=NAD83 +units=m +no_defs'
}
```

> We may need to add a function to application or util to "bridge the gap" to allow users to add a projection.

2. @theduckylittle would it make sense to keep projection definitions out of the coordinate display options? And then simply reference the defined projection in the coordinate display option:

```Javascript
// app.js

// define projection
app.addProjection({
    ref: 'EPSG:26915',
    def: '+proj=utm +zone=15 +ellps=GRS80 +datum=NAD83 +units=m +no_defs'
});

// then refer to it 
app.add(gm3.components.CoordinateDisplay, 'coordinate-display', {
    projections:  [
        {
            label: 'UTM15',
            ref: 'EPSG:26915'
        }
    ]
});
```

3. I added a `precision` property so users can truncate long coordinates, i.e.

```Javascript
{
    label: 'Lat,Lon',
    ref: 'EPSG:4326',
    precision: 3
}
```