### PR TITLE
Create a "smart" layer for rendering query results.

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -195,6 +195,8 @@
                 <td style="text-align: right">${{ properties.EMV_TOTAL | number | localize }}</td>
             </tr>
             ]]></template>
+
+            <transform attribute="EMV_TOTAL" function="number"/>
         </layer>
         <file>./demo/parcels/parcels.map</file>
 

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -179,23 +179,20 @@
             ]]></template>
             <template name="gridRow"><![CDATA[
             <tr 
-              onmouseenter="app.changeFeatures('highlight/highlight', {'PIN' : '{{ properties.PIN }}'}, {'displayClass' : 'red'})"
-              onmouseleave="app.changeFeatures('highlight/highlight', {'displayClass' : 'red'}, {'displayClass' : 'blue'})"
+              onmouseenter="app.highlightFeatures({'PIN' : '{{ properties.PIN }}'}, true)"
+              onmouseleave="app.clearHighlight()"
             >
-                <td>
-                  <a onClick="app.removeFeatures('highlight/highlight', {'PIN' : '{{ properties.PIN }}'}) ; app.removeQueryResults('{{ query }}', {'PIN' : '{{ properties.PIN }}'})">
-                    <i title="Remove from results" class="fa fa-trash"></i>
-                  </a>
-                </td>
                 <td>
                   <a onClick="app.zoomToExtent([{{ properties.boundedBy | join }}], 'EPSG:4326')" class="zoomto-link">
                     <i class="fa fa-search"></i> 
-                    {{ properties.PIN }}
                   </a>
+                </td>
+                <td>
+                  {{ properties.PIN }}
                 </td>
                 <td>{{ properties.OWNER_NAME }}</td>
                 <td style="text-align: right">${{ properties.EMV_TOTAL | number | localize }}</td>
-            </td>
+            </tr>
             ]]></template>
         </layer>
         <file>./demo/parcels/parcels.map</file>

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -89,15 +89,15 @@
 	</map-source>
 
 	<map-source name="minnesota_places" type="wfs" active="true" srs="EPSG:4326">
-        <layer name="gm:minnesota_places"/>
-
-		<style type="stylemap"><![CDATA[
-		{
-			"fill-outline-color" : "#f00",
-            "fill-color" : "#000077",
-			"label" : "${name}"
-		}
-		]]></style>
+        <layer name="gm:minnesota_places">
+            <style type="stylemap"><![CDATA[
+            {
+                "fill-outline-color" : "#f00",
+                "fill-color" : "#000077",
+                "label" : "${name}"
+            }
+            ]]></style>
+        </layer>
 
 		<url>/mapserver/cgi-bin/tinyows</url>
 
@@ -117,6 +117,12 @@
 
     <map-source name="vector-parcels" type="mapserver-wfs">
         <layer name="ms:parcels" selectable="true" title="Parcels">
+            <style><![CDATA[
+            {
+                "line-color" : "#00A138",
+                "line-width" : 2
+            }
+            ]]></style>
             <template name="identify"><![CDATA[
                 <div class="identify-result">
                     <div class="feature-class">Vector Parcel</div>
@@ -192,13 +198,7 @@
             </td>
             ]]></template>
         </layer>
-		<file>./demo/parcels/parcels.map</file>
-        <style><![CDATA[
-		{
-			"line-color" : "#00A138",
-            "line-width" : 2
-		}
-        ]]></style>
+        <file>./demo/parcels/parcels.map</file>
 
     </map-source>
 

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -42,6 +42,7 @@
 		<attribute name="label_only" type="checkbox" default-value="false" label="Only show label in print?"/>
 	</map-source>
 
+    <!--
 	<map-source name="highlight" type="vector">
         <layer name="highlight" status="on">
             <style><![CDATA[
@@ -57,6 +58,7 @@
             ]]></style>
         </layer>
 	</map-source>
+    -->
 
 	<map-source name="census_cities" type="wfs" active="true" srs="EPSG:4269"> 
 		<style><![CDATA[

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     ]
   },
   "jest": {
-    "transformIgnorePatterns" : [
-        "node_modules/(?!ol|mapbox)"
+    "transformIgnorePatterns": [
+      "node_modules/(?!ol|mapbox)"
     ],
     "setupFiles": [
       "./tests/setup.js"
@@ -68,6 +68,7 @@
     "mapbox-to-ol-style": "^2.4.2",
     "mapskin": "^1.0.0",
     "markup-js": "^1.5.21",
+    "md5": "^2.2.1",
     "ol": "^4.1.1",
     "papaparse": "^4.1.2",
     "proj4": "^2.4.3",

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -162,7 +162,6 @@ export function addFromXml(xml, config) {
         zIndex: xml.getAttribute('z-index'),
         queryable: util.parseBoolean(xml.getAttribute('queryable'), true),
         refresh: null,
-        style: null,
         layers: [],
         params: {}
     }
@@ -206,18 +205,6 @@ export function addFromXml(xml, config) {
         }
     }
 
-    // check to see if there are any style definitions
-    let style = util.getTagContents(xml, 'style', false);
-    if(style && style.length > 0) {
-        // convert to JSON
-        try {
-            map_source.style = JSON.parse(style);
-        } catch(err) {
-            console.error('There was an error parsing the style for: ', map_source.name);
-            console.error('Error details', err);
-        }
-    }
-
 
     // mix in the params
     Object.assign(map_source.params, parseParams(xml));
@@ -236,7 +223,9 @@ export function addFromXml(xml, config) {
             selectable: util.parseBoolean(layerXml.getAttribute('selectable')),
             label: layer_title ? layer_title : map_source.label,
             templates: {},
-            legend: null
+            legend: null,
+            style: null,
+            filter: null,
         };
 
         // user defined legend.
@@ -270,6 +259,20 @@ export function addFromXml(xml, config) {
             }
 
             layer.templates[template_name] = template_def;
+
+
+        }
+
+        // check to see if there are any style definitions
+        let style = util.getTagContents(layerXml, 'style', false);
+        if(style && style.length > 0) {
+            // convert to JSON
+            try {
+                layer.style = JSON.parse(style);
+            } catch(err) {
+                console.error('There was an error parsing the style for: ', map_source.name);
+                console.error('Error details', err);
+            }
         }
 
         map_layers.push(addLayer(map_source.name, layer));

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -268,7 +268,7 @@ export function addFromXml(xml, config) {
         // catalog the transforms for the layer
         const transforms = layerXml.getElementsByTagName('transform');
         for(const transform of transforms) {
-            layer.transforms[transform.getAttribute('attribute')] = 
+            layer.transforms[transform.getAttribute('attribute')] =
                 transform.getAttribute('function');
         }
 

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -227,6 +227,7 @@ export function addFromXml(xml, config) {
             legend: null,
             style: null,
             filter: null,
+            transforms: {},
         };
 
         // user defined legend.
@@ -263,6 +264,15 @@ export function addFromXml(xml, config) {
 
 
         }
+
+        // catalog the transforms for the layer
+        const transforms = layerXml.getElementsByTagName('transform');
+        for(const transform of transforms) {
+            layer.transforms[transform.getAttribute('attribute')] = 
+                transform.getAttribute('function');
+        }
+
+
 
         // check to see if there are any style definitions
         let style = util.getTagContents(layerXml, 'style', false);

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -30,10 +30,16 @@ import { MAPSOURCE } from '../actionTypes';
 
 import * as util from '../util';
 
+var MS_Z_INDEX = 100000;
+
 /** Add a map-source using a MapSource
  *  object.
  */
 export function add(mapSource) {
+    if(typeof(mapSource.zIndex) !== 'number') {
+        mapSource.zIndex = MS_Z_INDEX;
+        MS_Z_INDEX--;
+    }
     return {
         type: MAPSOURCE.ADD,
         mapSource
@@ -146,8 +152,6 @@ function mapServerToWFS(msXml, conf) {
     return wfs_conf;
 }
 
-var MS_Z_INDEX = 100000;
-
 /** Add a map-source from XML
  *
  */
@@ -169,9 +173,6 @@ export function addFromXml(xml, config) {
     // handle setting up the zIndex
     if(map_source.zIndex) {
         map_source.zIndex = parseInt(map_source.zIndex);
-    } else {
-        map_source.zIndex = MS_Z_INDEX;
-        MS_Z_INDEX--;
     }
 
     // try to get an opacity,  if it won't parse then default to 1.0

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -143,6 +143,7 @@ class Application {
                 'fill-opacity': 0.25,
                 'line-opacity': 0.25,
             },
+            filter: []
         }));
         // the "hot" layer shows the features as red on the map,
         //  namely useful for hover-over functionality.

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -132,6 +132,39 @@ class Application {
         for(let action of toolbar_actions) {
             this.store.dispatch(action);
         }
+
+        // add the highlight layer.
+        mapSourceActions.add({
+            type: 'query-layer',
+            name: 'highlight',
+            style:  {
+                'circle-radius': 4,
+                'circle-color': '#ffff00',
+                'circle-stroke-color': '#ffff00',
+                'line-color' : '#ffff00',
+                'line-width' : 4,
+                'fill-color' : '#ffff00',
+                'fill-opacity' : 0.25
+            }
+        });
+
+        // Add the selection layer,
+        //  this is used to preview the user's selection.
+        mapSourceActions.add({
+            type: 'vector',
+            name: 'selection',
+            style: {
+                'circle-radius': 4,
+                'circle-color': '#ffff00',
+                'circle-stroke-color': '#ffff00',
+                'line-color' : '#ffff00',
+                'line-width' : 4,
+                'fill-color' : '#ffff00',
+                'fill-opacity' : 0.25
+            }
+        });
+                
+                
     }
 
     loadMapbook(options) {

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -114,7 +114,7 @@ class Application {
 
     populateMapbook(mapbookXml) {
 
-        // add a layer that listens for changes 
+        // add a layer that listens for changes
         //  to the query results.  This hs
         this.store.dispatch(mapSourceActions.add({
             name: 'results',
@@ -126,6 +126,9 @@ class Application {
             refresh: null,
             layers: [],
             params: {},
+            // stupid high z-index to ensure results are
+            //  on top of everything else.
+            zIndex: 200000,
         }));
         this.store.dispatch(mapSourceActions.addLayer('results', {
             name: 'results',
@@ -134,10 +137,11 @@ class Application {
                 'circle-radius': 4,
                 'circle-color': '#ffff00',
                 'circle-stroke-color': '#ffff00',
-                'line-color' : '#ffff00',
-                'line-width' : 4,
-                'fill-color' : '#ffff00',
-                'fill-opacity' : 0.25
+                'line-color': '#ffff00',
+                'line-width': 4,
+                'fill-color': '#ffff00',
+                'fill-opacity': 0.25,
+                'line-opacity': 0.25,
             },
         }));
         // the "hot" layer shows the features as red on the map,
@@ -149,10 +153,11 @@ class Application {
                 'circle-radius': 4,
                 'circle-color': '#ff0000',
                 'circle-stroke-color': '#ff0000',
-                'line-color' : '#ff0000',
-                'line-width' : 4,
-                'fill-color' : '#ff0000',
-                'fill-opacity' : 0.25
+                'line-color': '#ff0000',
+                'line-width': 4,
+                'fill-color': '#ff0000',
+                'fill-opacity': 0.50,
+                'line-opacity': 0.50,
             },
             filter: ['==', 'displayClass', 'hot']
         }));
@@ -194,8 +199,8 @@ class Application {
             }
         });
         */
-                
-                
+
+
     }
 
     loadMapbook(options) {
@@ -396,7 +401,7 @@ class Application {
     /* Short hand for toggling the highlight of features.
      */
     highlightFeatures(filter, on) {
-        const props = {displayClass: on ? 'hot': ''};
+        const props = {displayClass: on ? 'hot' : ''};
         this.changeResultFeatures(filter, props);
     }
 

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -113,6 +113,50 @@ class Application {
     }
 
     populateMapbook(mapbookXml) {
+
+        // add a layer that listens for changes 
+        //  to the query results.  This hs
+        this.store.dispatch(mapSourceActions.add({
+            name: 'results',
+            urls: [],
+            type: 'vector',
+            label: 'Results',
+            opacity: 1.0,
+            queryable: false,
+            refresh: null,
+            layers: [],
+            params: {},
+        }));
+        this.store.dispatch(mapSourceActions.addLayer('results', {
+            name: 'results',
+            on: true,
+            style: {
+                'circle-radius': 4,
+                'circle-color': '#ffff00',
+                'circle-stroke-color': '#ffff00',
+                'line-color' : '#ffff00',
+                'line-width' : 4,
+                'fill-color' : '#ffff00',
+                'fill-opacity' : 0.25
+            },
+        }));
+        // the "hot" layer shows the features as red on the map,
+        //  namely useful for hover-over functionality.
+        this.store.dispatch(mapSourceActions.addLayer('results', {
+            name: 'results-hot',
+            on: true,
+            style: {
+                'circle-radius': 4,
+                'circle-color': '#ff0000',
+                'circle-stroke-color': '#ff0000',
+                'line-color' : '#ff0000',
+                'line-width' : 4,
+                'fill-color' : '#ff0000',
+                'fill-opacity' : 0.25
+            },
+            filter: ['==', 'displayClass', 'hot']
+        }));
+
         // load the map-sources
         let sources = mapbookXml.getElementsByTagName('map-source');
         for(let i = 0, ii = sources.length; i < ii; i++) {
@@ -132,33 +176,6 @@ class Application {
         for(let action of toolbar_actions) {
             this.store.dispatch(action);
         }
-
-        // add a layer that listens for changes 
-        //  to the query results.  This hs
-        this.store.dispatch(mapSourceActions.add({
-            name: 'results',
-            urls: [],
-            type: 'vector',
-            label: 'Results',
-            opacity: 1.0,
-            queryable: false,
-            refresh: null,
-            layers: [],
-            params: {},
-            style:  {
-                'circle-radius': 4,
-                'circle-color': '#ffff00',
-                'circle-stroke-color': '#ffff00',
-                'line-color' : '#ffff00',
-                'line-width' : 4,
-                'fill-color' : '#ffff00',
-                'fill-opacity' : 0.25
-            },
-        }));
-        this.store.dispatch(mapSourceActions.addLayer('results', {
-            name: 'results',
-            on: true,
-        }));
 
         // Add the selection layer,
         //  this is used to preview the user's selection.

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -133,10 +133,18 @@ class Application {
             this.store.dispatch(action);
         }
 
-        // add the highlight layer.
-        mapSourceActions.add({
-            type: 'query-layer',
-            name: 'highlight',
+        // add a layer that listens for changes 
+        //  to the query results.  This hs
+        this.store.dispatch(mapSourceActions.add({
+            name: 'results',
+            urls: [],
+            type: 'vector',
+            label: 'Results',
+            opacity: 1.0,
+            queryable: false,
+            refresh: null,
+            layers: [],
+            params: {},
             style:  {
                 'circle-radius': 4,
                 'circle-color': '#ffff00',
@@ -145,11 +153,16 @@ class Application {
                 'line-width' : 4,
                 'fill-color' : '#ffff00',
                 'fill-opacity' : 0.25
-            }
-        });
+            },
+        }));
+        this.store.dispatch(mapSourceActions.addLayer('results', {
+            name: 'results',
+            on: true,
+        }));
 
         // Add the selection layer,
         //  this is used to preview the user's selection.
+        /*
         mapSourceActions.add({
             type: 'vector',
             name: 'selection',
@@ -163,6 +176,7 @@ class Application {
                 'fill-opacity' : 0.25
             }
         });
+        */
                 
                 
     }

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -387,6 +387,25 @@ class Application {
         this.store.dispatch(mapSourceActions.changeFeatures(ms_name, layer_name, filter, properties));
     }
 
+    /* Shorthand for manipulating result features.
+     */
+    changeResultFeatures(filter, properties) {
+        this.changeFeatures('results/results', filter, properties);
+    }
+
+    /* Short hand for toggling the highlight of features.
+     */
+    highlightFeatures(filter, on) {
+        const props = {displayClass: on ? 'hot': ''};
+        this.changeResultFeatures(filter, props);
+    }
+
+    /* Clear highlight features
+     */
+    clearHighlight() {
+        this.highlightFeatures({displayClass: 'hot'}, false);
+    }
+
     /** Clears the UI hint.  Used by applications to indicate
      *  that the previous "hint" has been handled.
      */

--- a/src/gm3/components/grid.jsx
+++ b/src/gm3/components/grid.jsx
@@ -63,35 +63,35 @@ class FilterModal extends ModalDialog {
     setFilter() {
         const value = this.state.value;
         const property = this.props.column.property;
-        let filter_def = '';
+
+        const new_filters = [];
 
         if(this.props.column.filter.type === 'list') {
-            filter_def = {
-                type: 'list',
-                value: value
-            }
+            new_filters.push(["in", property, value]);
         } else if(this.props.column.filter.type === 'range') {
-            filter_def = {
-                type: 'range'
-            }
             if(this.state.min !== '') {
-                filter_def.min = this.state.min;
+                new_filters.push([">=", property, this.state.min]);
             }
             if(this.state.max !== '') {
-                filter_def.max = this.state.max;
+                new_filters.push(["<=", property, this.state.max]);
             }
         } else {
             // straight equals...
-            filter_def = value;
+            new_filters.push(["==", property, value]);
         }
 
-        const new_filter = {};
-        new_filter[property] = filter_def;
-
-        // add/update this filter.
+        // remove the filters from the property
         this.props.store.dispatch(
-            addFilter(this.props.queryId, new_filter)
+            removeFilter(this.props.queryId, property)
         );
+
+        // add the new filtres.
+        for(const new_filter of new_filters) {
+            // add/update this filter.
+            this.props.store.dispatch(
+                addFilter(this.props.queryId, new_filter)
+            );
+        }
     }
 
     close(status) {

--- a/src/gm3/components/grid.jsx
+++ b/src/gm3/components/grid.jsx
@@ -67,7 +67,7 @@ class FilterModal extends ModalDialog {
         const new_filters = [];
 
         if(this.props.column.filter.type === 'list') {
-            new_filters.push(["in", property, value]);
+            new_filters.push(["in", property].concat(value));
         } else if(this.props.column.filter.type === 'range') {
             if(this.state.min !== '') {
                 new_filters.push([">=", property, this.state.min]);

--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -75,27 +75,36 @@ export function createLayer(mapSource) {
         source
     };
 
-    if(mapSource.style) {
+    // with vector layers each sub-layer is a style grouping
+    // in defineSource, only the FIRST layer's name is used
+    // as the WFS type name.
+    const layers = [];
+    for(const layer of mapSource.layers) {
+        const layer_def = {
+            id: layer.name,
+            // source is a contant that is used to dummy up 
+            //  the Mapbox styles
+            source: 'dummy-source',
+            paint: layer.style,
+        };
+
+        // check to see if there is a filter 
+        //  set on the layer.  This uses the Mapbox GL/JS 
+        //  filters.
+        if(layer.filter !== null) {
+            layer_def.filter = layer.filter;
+        }
+
+        layers.push(layer_def); 
+    }
+
+    // If there are any styles defined
+    //  then use them to style the layer.
+    // Otherwise this will use the built-in OL styles.
+    if(layers.length > 0) {
         opts.style = olMapboxStyle.getStyleFunction({
             'version': 8,
-            'layers': [
-                {
-                    'id': 'red',
-                    'source': 'dummy-source',
-                    'filter': ['==', 'displayClass', 'red'],
-                    'paint': {
-                        'line-color': '#ff0000',
-                        'line-width': 2,
-                        'fill-color': '#ff0000',
-                        'fill-opacity': 0.5
-                    }
-                },
-                {
-                    'id': 'dummy',
-                    'source': 'dummy-source',
-                    'paint': mapSource.style
-                }
-            ],
+            'layers': layers,
             'dummy-source': [
                 {
                     'type': 'vector'

--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -88,27 +88,26 @@ export function createLayer(mapSource) {
     for(const layer of mapSource.layers) {
         const layer_def = {
             id: layer.name,
-            // source is a contant that is used to dummy up 
+            // source is a contant that is used to dummy up
             //  the Mapbox styles
             source: 'dummy-source',
             paint: layer.style,
         };
 
-        // check to see if there is a filter 
-        //  set on the layer.  This uses the Mapbox GL/JS 
+        // check to see if there is a filter
+        //  set on the layer.  This uses the Mapbox GL/JS
         //  filters.
         if(layer.filter !== null) {
             layer_def.filter = layer.filter;
         }
 
-        layers.push(layer_def); 
+        layers.push(layer_def);
     }
 
     // If there are any styles defined
     //  then use them to style the layer.
     // Otherwise this will use the built-in OL styles.
     if(layers.length > 0) {
-        opts.style = olMapboxStyle.getStyleFunction({
         opts.style = getStyleFunction({
             'version': 8,
             'layers': layers,

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -36,7 +36,7 @@ import Request from 'reqwest';
 import { connect } from 'react-redux';
 
 import uuid from 'uuid';
-import { createHash } from 'crypto';
+import md5 from 'md5';
 
 import getStyleFunction from 'mapbox-to-ol-style';
 
@@ -428,9 +428,9 @@ class Map extends Component {
             if(query.progress === 'finished') {
                 // check the filters
                 const filter_json = JSON.stringify(query.filter);
-                const filter_md5 = createHash('md5').update(filter_json).digest('hex');
+                const filter_md5 = md5(filter_json);
 
-                if(this.currentQueryId !== query_id 
+                if(this.currentQueryId !== query_id
                    || this.currentQueryFilter !== filter_md5) {
 
                     this.renderQueryLayer(query);

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -362,7 +362,15 @@ class Map extends Component {
                     for(const feature of features) {
                         feature.setGeometry(feature.getGeometry().transform(query_projection, projection));
                     }
+
+                    // features to add
                     let js_features = (new GeoJSONFormat()).writeFeaturesObject(features).features;
+
+                    // get the transforms for the layer
+                    const transforms = mapSourceActions.getLayerByPath(this.props.store, queryLayer).transforms;
+
+                    // apply the transforms
+                    js_features = util.transformFeatures(transforms, js_features);
 
                     this.props.store.dispatch(
                         mapActions.resultsForQuery(queryId, queryLayer, false, js_features)

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -874,17 +874,6 @@ class Map extends Component {
      *  cycle where the state can get modified.
      */
     componentWillUpdate(nextProps, nextState) {
-        if(nextProps && nextProps.mapView.extent) {
-            let bbox = nextProps.mapView.extent.bbox;
-            const bbox_code = nextProps.mapView.extent.projection;
-            if(bbox_code) {
-                const map_proj = this.map.getView().getProjection();
-                bbox = ol.proj.transformExtent(bbox, ol.proj.get(bbox_code), map_proj);
-            }
-            // move the map to the new extent.
-            this.map.getView().fit(bbox, this.map.getSize());
-        }
-
         // check to see if the view has been altered.
         if(nextProps && nextProps.mapView) {
             const map_view = this.map.getView();
@@ -899,6 +888,17 @@ class Map extends Component {
                 this.map.getView().setCenter(view.center);
                 this.map.getView().setResolution(view.resolution);
             }
+        }
+
+        if(nextProps && nextProps.mapView.extent) {
+            let bbox = nextProps.mapView.extent.bbox;
+            const bbox_code = nextProps.mapView.extent.projection;
+            if(bbox_code) {
+                const map_proj = this.map.getView().getProjection();
+                bbox = ol.proj.transformExtent(bbox, ol.proj.get(bbox_code), map_proj);
+            }
+            // move the map to the new extent.
+            this.map.getView().fit(bbox, this.map.getSize());
         }
 
         // ensure that the selection features have been 'cleared'

--- a/src/gm3/reducers/query.js
+++ b/src/gm3/reducers/query.js
@@ -105,7 +105,7 @@ export default function queryReducer(state = default_query, action) {
             const query_id = uuid.v4();
             new_query[query_id] = Object.assign({}, action.query, {
                 progress: 'new',
-                filter: null,
+                filter: [],
                 results: {},
                 rendered: {}
             });
@@ -149,12 +149,18 @@ export default function queryReducer(state = default_query, action) {
             return removeQuery(state, action.id);
         case MAP.ADD_FILTER:
             new_query[action.id] = Object.assign({}, state[action.id], {
-                filter: Object.assign({}, state[action.id].filter, action.filter)
+                filter: state[action.id].filter.concat([action.filter])
             });
             return Object.assign({}, state, new_query);
         case MAP.REMOVE_FILTER:
-            const new_filter = Object.assign({}, state[action.id].filter);
-            delete new_filter[action.field];
+            const new_filter = [];
+            // rebuild the filter array based without the
+            //  filters for a given field.
+            for(const filter in state[action.id].filter) {
+                if(filter.length > 2 && filter[1] !== action.field) {
+                    new_filter.push(filter);
+                }
+            }
 
             new_query[action.id] = Object.assign({}, state[action.id], {
                 filter: new_filter

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -311,7 +311,7 @@ export function featureMatch(feature, filter) {
 export function filterFeatures(features, filter, inverse = true) {
     let new_features = [];
 
-    // the createFilter function is from mapbox! 
+    // the createFilter function is from mapbox!
     // uses the mapbox gl style filters.
     const filter_function = createFilter(['all'].concat(filter));
 

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -26,6 +26,8 @@ import Request from 'reqwest';
 
 import GeoJSONFormat from 'ol/format/geojson';
 
+import createFilter from '@mapbox/mapbox-gl-style-spec/feature_filter';
+
 /** Collection of handy functions
  */
 
@@ -309,8 +311,12 @@ export function featureMatch(feature, filter) {
 export function filterFeatures(features, filter, inverse = true) {
     let new_features = [];
 
+    // the createFilter function is from mapbox! 
+    // uses the mapbox gl style filters.
+    const filter_function = createFilter(['all'].concat(filter));
+
     for(let feature of features) {
-        if(inverse !== featureMatch(feature, filter)) {
+        if(inverse !== filter_function(feature)) {
             new_features.push(feature);
         }
     }
@@ -333,6 +339,7 @@ export function matchFeatures(features, filter) {
     if(filter === null || filter === false) {
         return features;
     }
+
     return filterFeatures(features, filter, false);
 }
 
@@ -620,3 +627,35 @@ export function xhr(opts) {
     return Request(opts);
 }
 
+
+/* Convert the data type of feature properties.
+ *
+ * @param transforms Object of transforms to apply.
+ * @param features   Array of GeoJSON features.
+ *
+ * @return The array of GeoJSON features.
+ */
+export function transformFeatures(transforms, features) {
+    if(typeof(transforms) !== 'object') {
+        return features;
+    }
+
+    for(const feature of features) {
+        for(const prop in transforms) {
+            let value = feature.properties[prop];
+            switch(transforms[prop]) {
+                case 'string':
+                    value = '' + value;
+                    break
+                case 'number':
+                    value = parseFloat(value);
+                    break;
+                default:
+                    // do nothing on default.
+            }
+            feature.properties[prop] = value;
+        }
+    }
+
+    return features;
+}

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -132,23 +132,5 @@ function SelectService(Application, options) {
         //  this line has not finished, this prevents an accidental
         //  double-rendering.
         this.hasRendered[queryId] = true;
-
-        // render a set of features on a layer.
-        var all_features = [];
-        for(var i = 0, ii = query.layers.length; i < ii; i++) {
-            var path = query.layers[i];
-            if(query.results[path] && !query.results[path].failed) {
-                all_features = all_features.concat(query.results[path]);
-            }
-        }
-
-        // when features have been returned, clear out the old features
-        //  and put the new features on the highlight layer.
-        if(all_features.length > 0) {
-            Application.clearFeatures(this.highlightPath);
-            Application.addFeatures(this.highlightPath, all_features);
-        }
     }
-
-
 }

--- a/tests/gm3/util.test.js
+++ b/tests/gm3/util.test.js
@@ -23,46 +23,36 @@ describe('Filter Tests (matchFeatures)', () => {
     });
 
     test('Simple expression equals search {prop: value}', () => {
-        var filter = {'pin': '350010001050' }; 
-        expect(util.matchFeatures(features, filter)[0].properties.pin).toBe(filter.pin);
+        var pin = '350010001050';
+        var filter = [['==', 'pin', '350010001050']]; 
+        expect(util.matchFeatures(features, filter)[0].properties.pin).toBe(pin);
     });
-    test('Filter with equals type {prop: {type: equals, value}', () => {
-        var filter = {pin: {type: 'equals', value: '350010001050'}};
-        expect(util.matchFeatures(features, filter)[0].properties.pin).toBe(filter.pin.value);
-    });
-    test('Simple list filter {prop: []}', () => {
-        var filter = {pin: ['350010001050', '160020001550']};
+    test('Simple list filter', () => {
+        var pin = '350010001050';
+        var filter = [['in', 'pin', pin, '160020001550']];
         var results = util.matchFeatures(features, filter);
         expect(results.length).toBe(2);
 
         // reduce the "pin" set to a testable array.
         var pins = results.map((f) => { return f.properties.pin; });
-        expect(pins).toEqual(expect.arrayContaining(filter.pin));
+        expect(pins).toEqual(expect.arrayContaining([pin]));
     });
-    test('Filter with list type {prop: {type: list, value: []}', () => {
-        var filter = {pin: {type: 'list', value: ['350010001050', '160020001550']}};
-        var results = util.matchFeatures(features, filter);
-
-        expect(results.length).toBe(2);
-        // reduce the "pin" set to a testable array.
-        var pins = results.map((f) => { return f.properties.pin; });
-        expect(pins).toEqual(expect.arrayContaining(filter.pin.value));
-    });
-
     describe('Filter by range', () => {
         test('With min and max', () => {
-            var filter = {emv_total: {type: 'range', min: 250000, max: 500000}};
+            var filter = [
+                ['>=', 'emv_total', 250000],
+                ['<=', 'emv_total', 500000]
+            ];
             expect(util.matchFeatures(features, filter).length).toBe(5);
         });
         test('With only min', () => {
-            var filter = {emv_total: {type: 'range', min: 300000}};
+            var filter = [['>=', 'emv_total', 300000]];
             expect(util.matchFeatures(features, filter).length).toBe(3);
         });
         test('With only max', () => {
-            var filter = {emv_total: {type: 'range', max: 300000}};
+            var filter = [['<=', 'emv_total', 300000]];
             expect(util.matchFeatures(features, filter).length).toBe(7);
         });
-
     });
 
 });


### PR DESCRIPTION
This PR accomplishes a few things:

1. Removes the custom filtering that I wrote to handle the grid filtering in favor of using the more feature complete mapbox "createFunction".  All the necessary components have been updated to reflect that.
2. Adds a new "transform" tag to layers so that a data type can be specified for a particular attribute.  When we get to feature editing this will probably need to come up again as we'll actually want more metadata about columns than this functionality provides.
3. The "highlight" layer has been removed in favor of an internal "results" source and layer.  That "results" layer is the one that is tied to the same display as the grid.  Ergo, both the grid and the layer will match when a filter is set for a query.
4. Multiple "layers" can now be defined for a vector map-source. The first "layer" is still used to set the type name for WFS requests, however, subsequent layers can define filters and styles for the layer. This also moves <style> into <layer> instead of being a part of <map-source>.
5. A small change to z-ordering was made.  A lot of the early code still assumes defaults will be set by the mapbook (this could use additional follow up work, actually) including the z-ordering.   There is a change that moves automatic z-ordering assignment out of the mapbook and into the "add" action.
6. "highlighting" now has some meta functions in application so that we can change the underlaying implementation more fluidly into the future.  