### PR TITLE
Always hint to open the super tab. refs: #81

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -37,7 +37,7 @@ var app = new gm3.Application({
 app.uiUpdate = function(ui) {
     // when the UI hint is set for the service manager
     //  show the service manager tab.
-    if(ui.hint == 'service-manager') {
+    if(ui.hint == 'service-manager' || ui.hint == 'service-start') {
         showTabByName('service-tab');
         app.clearHint();
     }

--- a/src/gm3/components/toolbar.jsx
+++ b/src/gm3/components/toolbar.jsx
@@ -32,7 +32,7 @@ import { connect } from 'react-redux';
 import { startTool } from '../actions/toolbar';
 
 import { startService } from '../actions/service';
-import { runAction } from '../actions/ui';
+import { runAction, setUiHint } from '../actions/ui';
 
 class Toolbar extends Component {
 
@@ -43,10 +43,11 @@ class Toolbar extends Component {
     }
 
     handleToolAction(tool) {
-        console.log('handleToolAction', tool);
         if(tool.actionType === 'service') {
-            console.log('dispatching startService...');
+            // start the service
             this.props.store.dispatch(startService(tool.name));
+            // give an indication that a new service has been started
+            this.props.store.dispatch(setUiHint('service-start'));
         } else if(tool.actionType === 'action') {
             this.props.store.dispatch(runAction(tool.name));
         }


### PR DESCRIPTION
Added a new UI hint that indicates when a service is "started."

This brings the super tab "to the top" whenever a user clicks to
start a service.