### PR TITLE
Attempt to fix travis-ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 #
 # (c) 2017 Dan "Ducky" Little
 #
+dist: trusty
 language: node_js
 node_js:
     - "node"


### PR DESCRIPTION
It looks like travis-ci updated their default node from v7.10.0 to v8.0.0.  This means the iltorb module is not available as a binary and needs to be built from source.  This in turn requires a C++11 compiler which in turn requires update the distro from Ubuntu Precise to Trusty.