### PR TITLE
Fixed the failing template issues.

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -262,9 +262,7 @@
 
 	<map-source name="borders" type="mapserver" title="City and County Borders">
 		<file>./demo/statedata/basemap.map</file>
-		<layer name="city_poly" status="off">
-            <template name="identify" src="./city.html"/>
-        </layer>
+		<layer name="city_poly" status="off"/>
 		<layer name="county_borders" status="off"/>
 	</map-source>
 

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -368,8 +368,20 @@ class Application {
                         resolve(layer.templates[template_name].contents);
                     }
                 } else {
-                    console.info('Failed to find template.', path, template_name);
-                    reject('Failed to find template. ' + path + '@' + template_name);
+                    // TODO: It may be wiser to allow services to specify
+                    //       how failure to find a template should be handled.
+                    //       - Identify will simply not render features.
+                    //       - Select could have a critical failure without
+                    //          an appropriate template.
+
+                    // commented this out because it was causing identify on layers
+                    //  without an identify template to fail the entire query.
+
+                    // console.info('Failed to find template.', path, template_name);
+                    // reject('Failed to find template. ' + path + '@' + template_name);
+
+                    // resolve this as an empty template.
+                    resolve('');
                 }
             }
         });

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -362,7 +362,12 @@ class Application {
                                 );
                                 // resolve this promise with the content
                                 resolve(content);
-                            }
+                            },
+                            // when there is an error fetching the template,
+                            // 404 or whatever, return a blank template.
+                            error: function() {
+                                resolve('');
+                            },
                         });
                     } else {
                         resolve(layer.templates[template_name].contents);


### PR DESCRIPTION
1. Removed the missing template from the mapbook
2. Reworked the getTemplate promise to ALWAYS resolve, it now resolves to a blank template on failure to load.