### PR TITLE
Fix for tab overflow scrolling bug.

### DIFF
--- a/examples/desktop/app.css
+++ b/examples/desktop/app.css
@@ -31,8 +31,11 @@ body {
 
 #tabs, #map, #results-grid{
     position: absolute;
-    overflow: auto;
     top: 75px; left: 0;
+}
+
+#map, #results-grid {
+    overflow: auto;
 }
 
 #map {

--- a/examples/desktop/debug.html
+++ b/examples/desktop/debug.html
@@ -44,7 +44,7 @@
         <div id="toolbar"></div>
     </div>
 
-    <div id="tabs">
+    <div id="tabs" class="tab-parent">
         <div class="tabs">
             <span id="catalog-tab" class="tab show" onclick="showTab('catalog', event)">Catalog</span>
             <span id="favorites-tab" class="tab" onclick="showTab('favorites', event)">Favorites</span>

--- a/examples/desktop/index.html
+++ b/examples/desktop/index.html
@@ -39,7 +39,7 @@
         <div id="toolbar"></div>
     </div>
 
-    <div id="tabs">
+    <div id="tabs" class="tab-parent">
         <div class="tabs">
             <span id="catalog-tab" class="tab show" onclick="showTab('catalog', event)">Catalog</span>
             <span id="favorites-tab" class="tab" onclick="showTab('favorites', event)">Favorites</span>

--- a/examples/desktop/tabs.css
+++ b/examples/desktop/tabs.css
@@ -1,3 +1,6 @@
+.tab-parent {
+    overflow: hidden;
+}
 
 .tab {
     border: solid 1px black;
@@ -30,4 +33,6 @@
 
 .tab-content.show {
     display: block;
+    height: 100%;
+    overflow: auto;
 }

--- a/examples/desktop/tabs.css
+++ b/examples/desktop/tabs.css
@@ -33,6 +33,8 @@
 
 .tab-content.show {
     display: block;
-    height: 100%;
     overflow: auto;
+    position: absolute;
+    top: 35px; bottom: 0;
+    width: 100%;
 }


### PR DESCRIPTION
Scrolling tabs was causing the tab headers to scroll off.