### PR TITLE
Fix for "forgetting" select setting.

### DIFF
--- a/src/gm3/components/serviceInputs/text.jsx
+++ b/src/gm3/components/serviceInputs/text.jsx
@@ -32,7 +32,7 @@ export default class TextInput extends Component {
         super(props);
 
         this.state = {
-            value: props.field.default ? props.field.default : ''
+            value: props.value ? props.value : props.field.default ? props.field.default : ''
         };
 
         this.onChange = this.onChange.bind(this);

--- a/src/gm3/components/serviceManager.jsx
+++ b/src/gm3/components/serviceManager.jsx
@@ -417,7 +417,7 @@ class ServiceManager extends Component {
             case 'length':
                 return (<LengthInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
             case 'text':
-            value:
+            default:
                 return (<TextInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
         }
     }

--- a/src/gm3/components/serviceManager.jsx
+++ b/src/gm3/components/serviceManager.jsx
@@ -410,15 +410,15 @@ class ServiceManager extends Component {
         this.fieldValues[this.props.queries.service][name] = value;
     }
 
-    getServiceField(i, field) {
+    getServiceField(i, field, value) {
         switch(field.type) {
             case 'select':
-                return (<SelectInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field}/>);
+                return (<SelectInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
             case 'length':
-                return (<LengthInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field}/>);
+                return (<LengthInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
             case 'text':
-            default:
-                return (<TextInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field}/>);
+            value:
+                return (<TextInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
         }
     }
 
@@ -476,8 +476,15 @@ class ServiceManager extends Component {
 
             for(let i = 0, ii = service_def.fields.length; i < ii; i++) {
                 const field = service_def.fields[i];
-                service_fields.push(this.getServiceField(i, field));
-                this.fieldValues[this.props.queries.service][field.name] = field.default;
+                let value = field.default;
+                if(this.fieldValues[this.props.queries.service][field.name]) {
+                    value = this.fieldValues[this.props.queries.service][field.name];
+                } else {
+                    this.fieldValues[this.props.queries.service][field.name] = value;
+                }
+
+                service_fields.push(this.getServiceField(i, field, value));
+
             }
 
             let buffer_controls = false;


### PR DESCRIPTION
Old bug: select, change to rail roads, go = rail roads.
         select, shows parcels selected, go = rail roads (should be parcels).

This was because the local "state" in the service manager has the value
set to rail roads yet parcels are what needed to be set.  This ensures the
inputs show what the service manager thinks they should be.

Follow up work: put more service info into the state tree.