### PR TITLE
Allow selecting features from the results layer.

### DIFF
--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -139,6 +139,8 @@ class Application {
         this.store.dispatch(mapSourceActions.addLayer('results', {
             name: 'results',
             on: true,
+            label: 'Results',
+            selectable: true,
             style: {
                 'circle-radius': 4,
                 'circle-color': '#ffff00',

--- a/src/gm3/components/catalog.jsx
+++ b/src/gm3/components/catalog.jsx
@@ -278,8 +278,6 @@ export class Catalog extends Component {
         if(layer.metadata_url) {
             metadata_tool = <MetadataTool href={layer.metadata_url} />
         }
-        console.log('LAYER', layer, layer.metadata_url);
-
         // check to see if the layer is on or not.
         const is_on = isLayerOn(this.props.mapSources, layer);
 


### PR DESCRIPTION
1. Small change in catalog to remove a console.log that got
   merged in accidentally.
2. Added "selectable: true" the results/highlight layer which
   allows users to do things like "Search for a parcel", select that
   parcel from the map, then buffer that shape to get other features.