### PR TITLE
Fix for IE iterator bug.

### DIFF
--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -273,9 +273,10 @@ export function addFromXml(xml, config) {
 
         // catalog the transforms for the layer
         const transforms = layerXml.getElementsByTagName('transform');
-        for(const transform of transforms) {
+        for(let x = 0, xx = transforms.length; x < xx; x++) {
+            const transform = transforms[x];
             layer.transforms[transform.getAttribute('attribute')] =
-                transform.getAttribute('function');
+            transform.getAttribute('function');
         }
 
 


### PR DESCRIPTION
IE treats the returns form getElementsByTagName as a "collection" instead of as a basic array and therefore support for ES6 "of" operator doesn't transpile correctly.  This fixes the transgression.