### PR TITLE
Major update to vector layer handling.

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -66,9 +66,9 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     app.registerService('search', SearchService);
     app.registerService('select', SelectService, {
         queryLayers: [
-            {value: 'vector-parcels/ms:parcels', label: 'Parcels'},
-            //{value: 'ags-vector-dc20/20', label: 'Dakota County Streets'},
-            {value: 'ags-vector-dc16/16', label: 'Dakota County Rail'}
+            {value: 'vector-parcels/parcels', label: 'Parcels'},
+            //{value: 'ags-vector-dc20/roads', label: 'Dakota County Streets'},
+            {value: 'ags-vector-dc16/railroads', label: 'Dakota County Rail'}
         ]
     });
 

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -26,7 +26,23 @@
 	</map-source>
 
     <map-source name="vector-parcels" type="mapserver-wfs">
-        <layer name="ms:parcels" selectable="true" title="Parcels">
+        <file>./demo/parcels/parcels.map</file>
+        <param name="typename" value="ms:parcels"/>
+        <transform attribute="EMV_TOTAL" function="number"/>
+
+        <layer name="big-money">
+            <style><![CDATA[
+            {
+                "fill-color": "#ffa500"
+            }
+            ]]></style>
+            <filter><![CDATA[
+            [">", "EMV_TOTAL", 500000]
+            ]]></filter>
+
+        </layer>
+
+        <layer name="parcels" selectable="true" title="Parcels">
             <style><![CDATA[
             {
                 "line-color" : "#00A138",
@@ -95,9 +111,7 @@
             </tr>
             ]]></template>
 
-            <transform attribute="EMV_TOTAL" function="number"/>
         </layer>
-        <file>./demo/parcels/parcels.map</file>
 
     </map-source>
 
@@ -190,8 +204,8 @@
 	</map-source>
 
     <map-source name="ags-vector-dc16" type="ags-vector">
-        <url>https://gis2.co.dakota.mn.us/arcgis/rest/services/DCGIS_OL_Transportation/MapServer/</url>
-        <layer name="16" selectable="true" title="Railroads">
+        <url>https://gis2.co.dakota.mn.us/arcgis/rest/services/DCGIS_OL_Transportation/MapServer/16</url>
+        <layer name="railroads" selectable="true" title="Railroads">
             <style><![CDATA[
             {
                 "line-color" : "#010138",
@@ -256,8 +270,8 @@
          once it is loaded.  Thus, it is not "in" the demo, but it is left here because it
          a good complex example and is a great stress test for the ags-vector driver. -->
     <!--map-source name="ags-vector-dc20" type="ags-vector">
-        <url>https://gis2.co.dakota.mn.us/arcgis/rest/services/DCGIS_OL_Transportation/MapServer/</url>
-        <layer name="20" selectable="true" title="Streets">
+        <url>https://gis2.co.dakota.mn.us/arcgis/rest/services/DCGIS_OL_Transportation/MapServer/20</url>
+        <layer name="roads" selectable="true" title="Streets">
             <style><![CDATA[
             {
                 "line-color" : "#A1A138",
@@ -393,7 +407,7 @@
                draw-point="true" draw-line="true" draw-polygon="true"
                draw-modify="true" draw-remove="true" />
 
-		<layer title="Vector Parcels" src="vector-parcels/ms:parcels">
+		<layer title="Vector Parcels" src="vector-parcels/parcels">
             <metadata>https://raw.githubusercontent.com/geomoose/gm3-demo-data/master/demo/parcels/LICENSE</metadata>
         </layer>
 		<!--
@@ -402,17 +416,17 @@
 		<group title="Overlays">
 			<group title="County Layers" expand="false">
 
-				<layer src="parcels/parcels" metadata="true" legend-toggle="true" tip="this a parcel layer, y'all" popups="true" refresh="10">
+				<layer src="parcels/parcels" metadata="true" legend-toggle="true" tip="this a parcel layer, y'all" refresh="10">
 					<metadata>https://raw.githubusercontent.com/geomoose/gm3-demo-data/master/demo/parcels/LICENSE</metadata>
 					<!--
 					<legend>images/logo_mini.gif</legend>
 					-->
 				</layer>
-				<layer title="Parcel Points" src="parcels/parcels_points" popups="true" minscale="6000" maxscale="20000" status="off">
-				</layer>
+				<layer title="Parcel Points" src="parcels/parcels_points" minscale="6000" maxscale="20000" status="off"/>
+                <layer title="Expensive Parcels" src="vector-parcels/big-money"/>
 				<layer title="City and County Boundaries" src="borders/county_borders;borders/city_poly"/>
-				<layer title="AGS Dakota County Rail" src="ags-vector-dc16/16"/>
-				<!--layer title="AGS Dakota County Streets" src="ags-vector-dc20/20"/-->
+				<layer title="AGS Dakota County Rail" src="ags-vector-dc16/railroads"/>
+				<!--layer title="AGS Dakota County Streets" src="ags-vector-dc20/roads"/-->
 			</group>
 			<layer src="pipelines/pipelines"></layer>
 			<layer title="Weather Radar" src="iastate/nexrad-n0r" />

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -530,50 +530,50 @@ export function setRefresh(mapSourceName, refreshSeconds) {
     }
 }
 
-export function addFeatures(mapSourceName, layerName, features) {
+export function addFeatures(mapSourceName, features) {
     return {
         type: MAPSOURCE.ADD_FEATURES,
-        mapSourceName, layerName, features
+        mapSourceName, features
     };
 }
 
-export function clearFeatures(mapSourceName, layerName) {
+export function clearFeatures(mapSourceName) {
     return {
         type: MAPSOURCE.CLEAR_FEATURES,
-        mapSourceName, layerName
+        mapSourceName
     };
 }
 
 
-export function removeFeatures(mapSourceName, layerName, filter) {
+export function removeFeatures(mapSourceName, filter) {
     return {
         type: MAPSOURCE.REMOVE_FEATURES,
-        mapSourceName, layerName, filter
+        mapSourceName, filter
     };
 }
 
 /* Remove a specific feature from the layer.
  */
-export function removeFeature(mapSourceName, layerName, id) {
+export function removeFeature(mapSourceName, id) {
     return {
         type: MAPSOURCE.REMOVE_FEATURE,
-        mapSourceName, layerName, id
+        mapSourceName, id
     };
 }
 
 /* Modify a feature's geomtery
  */
-export function modifyFeatureGeometry(mapSourceName, layerName, id, geometry) {
+export function modifyFeatureGeometry(mapSourceName, id, geometry) {
     return {
         type: MAPSOURCE.MODIFY_GEOMETRY,
-        mapSourceName, layerName, id, geometry
+        mapSourceName, id, geometry
     };
 }
 
-export function changeFeatures(mapSourceName, layerName, filter, properties) {
+export function changeFeatures(mapSourceName, filter, properties) {
     return {
         type: MAPSOURCE.CHANGE_FEATURES,
-        mapSourceName, layerName, filter, properties
+        mapSourceName, filter, properties
     };
 }
 

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -167,6 +167,7 @@ export function addFromXml(xml, config) {
         queryable: util.parseBoolean(xml.getAttribute('queryable'), true),
         refresh: null,
         layers: [],
+        transforms: {},
         params: {}
     }
 
@@ -206,6 +207,13 @@ export function addFromXml(xml, config) {
         }
     }
 
+    // catalog the transforms for the layer
+    const transforms = xml.getElementsByTagName('transform');
+    for(let x = 0, xx = transforms.length; x < xx; x++) {
+        const transform = transforms[x];
+        map_source.transforms[transform.getAttribute('attribute')] =
+        transform.getAttribute('function');
+    }
 
     // mix in the params
     Object.assign(map_source.params, parseParams(xml));
@@ -227,7 +235,6 @@ export function addFromXml(xml, config) {
             legend: null,
             style: null,
             filter: null,
-            transforms: {},
         };
 
         // user defined legend.
@@ -271,16 +278,6 @@ export function addFromXml(xml, config) {
 
         }
 
-        // catalog the transforms for the layer
-        const transforms = layerXml.getElementsByTagName('transform');
-        for(let x = 0, xx = transforms.length; x < xx; x++) {
-            const transform = transforms[x];
-            layer.transforms[transform.getAttribute('attribute')] =
-            transform.getAttribute('function');
-        }
-
-
-
         // check to see if there are any style definitions
         let style = util.getTagContents(layerXml, 'style', false);
         if(style && style.length > 0) {
@@ -289,6 +286,18 @@ export function addFromXml(xml, config) {
                 layer.style = JSON.parse(style);
             } catch(err) {
                 console.error('There was an error parsing the style for: ', map_source.name);
+                console.error('Error details', err);
+            }
+        }
+
+        // check to see if there are any filter definitions
+        let filter = util.getTagContents(layerXml, 'filter', false);
+        if(filter && filter.length > 0) {
+            // convert to JSON
+            try {
+                layer.filter = JSON.parse(filter);
+            } catch(err) {
+                console.error('There was an error parsing the filter for: ', map_source.name);
                 console.error('Error details', err);
             }
         }

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -484,16 +484,14 @@ class Application {
      */
     clearFeatures(path) {
         const ms_name = util.getMapSourceName(path);
-        const layer_name = util.getLayerName(path);
-        this.store.dispatch(mapSourceActions.clearFeatures(ms_name, layer_name));
+        this.store.dispatch(mapSourceActions.clearFeatures(ms_name));
     }
 
     /** Add features to a vector layer.
      */
     addFeatures(path, features) {
         const ms_name = util.getMapSourceName(path);
-        const layer_name = util.getLayerName(path);
-        this.store.dispatch(mapSourceActions.addFeatures(ms_name, layer_name, features));
+        this.store.dispatch(mapSourceActions.addFeatures(ms_name, features));
     }
 
     /** Removes features from a query.
@@ -508,16 +506,14 @@ class Application {
      */
     removeFeatures(path, filter) {
         const ms_name = util.getMapSourceName(path);
-        const layer_name = util.getLayerName(path);
-        this.store.dispatch(mapSourceActions.removeFeatures(ms_name, layer_name, filter));
+        this.store.dispatch(mapSourceActions.removeFeatures(ms_name, filter));
     }
 
     /** Change the features on a vectory layer with a filter.
      */
     changeFeatures(path, filter, properties) {
         const ms_name = util.getMapSourceName(path);
-        const layer_name = util.getLayerName(path);
-        this.store.dispatch(mapSourceActions.changeFeatures(ms_name, layer_name, filter, properties));
+        this.store.dispatch(mapSourceActions.changeFeatures(ms_name, filter, properties));
     }
 
     /* Shorthand for manipulating result features.

--- a/src/gm3/components/catalog/tools.jsx
+++ b/src/gm3/components/catalog/tools.jsx
@@ -77,7 +77,7 @@ class ClearDialog extends ModalDialog {
         if(status === 'clear') {
             let src = this.props.layer.src[0];
             this.props.store.dispatch(
-                msActions.clearFeatures(src.mapSourceName, src.layerName));
+                msActions.clearFeatures(src.mapSourceName));
         }
         this.setState({open: false});
     }

--- a/src/gm3/components/catalog/tools/upload.jsx
+++ b/src/gm3/components/catalog/tools/upload.jsx
@@ -117,7 +117,7 @@ class UploadModal extends Modal {
                         let src = self.props.layer.src[0];
                         // kick off the event
                         self.props.store.dispatch(msActions.addFeatures(
-                            src.mapSourceName, src.layerName, collection.features));
+                            src.mapSourceName, collection.features));
 
                         // TODO: Notify the user that n-number of features
                         //       were added to the layer.

--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -49,18 +49,18 @@ function defineSource(mapSource) {
             format: new GML2Format({}),
             projection: 'EPSG:4326',
             url: function(extent) {
-                // http://localhost:8080/mapserver/cgi-bin/tinyows?
-                // service=WFS&version=1.1.0&request=GetFeature&typename=gm:minnesota_places
+                if(typeof(mapSource.params.typename) === 'undefined') {
+                    console.error('No "typename" param defined for a WFS layer. This will fail.');
+                }
 
-                let url_params = Object.assign({}, mapSource.params,
-                    {typename: mapSource.layers[0].name}, {
-                        'srsname': 'EPSG:3857',
-                        'outputFormat': 'text/xml; subtype=gml/2.1.2',
-                        'service': 'WFS',
-                        'version': '1.1.0',
-                        'request': 'GetFeature',
-                        'bbox': extent.concat('EPSG:3857').join(',')
-                    });
+                let url_params = Object.assign({}, mapSource.params, {
+                    'srsname': 'EPSG:3857',
+                    'outputFormat': 'text/xml; subtype=gml/2.1.2',
+                    'service': 'WFS',
+                    'version': '1.1.0',
+                    'request': 'GetFeature',
+                    'bbox': extent.concat('EPSG:3857').join(',')
+                });
 
                 return mapSource.urls[0] + '?' + util.formatUrlParameters(url_params);
             },
@@ -71,9 +71,7 @@ function defineSource(mapSource) {
         // This performs a basic query based on the bounding box.
         return {
             loader: function(extent, resolution, proj) {
-                // https://heigeo.houstoneng.com/arcgis/rest/services/
-                //  GeoMoose/GeoMooseMap/FeatureServer/0
-                let url = mapSource.urls[0] + mapSource.layers[0].name + '/query/';
+                let url = mapSource.urls[0] + '/query/';
 
                 // the E**I language can get a bit complicated but
                 //  this is the format for a basic BBOX query.
@@ -178,6 +176,43 @@ function defineSource(mapSource) {
     return {}
 }
 
+/** Return a style function for the layer.
+ *
+ */
+function defineStyle(mapSource) {
+    const layers = [];
+    for(const layer of mapSource.layers) {
+        if(layer.on === true) {
+            const layer_def = {
+                id: layer.name,
+                // source is a contant that is used to dummy up
+                //  the Mapbox styles
+                source: 'dummy-source',
+                paint: layer.style,
+            };
+
+            // check to see if there is a filter
+            //  set on the layer.  This uses the Mapbox GL/JS
+            //  filters.
+            if(layer.filter !== null) {
+                layer_def.filter = layer.filter;
+            }
+
+            layers.push(layer_def);
+        }
+    }
+
+    return getStyleFunction({
+        'version': 8,
+        'layers': layers,
+        'dummy-source': [
+            {
+                'type': 'vector'
+            }
+        ]
+    }, 'dummy-source');
+}
+
 /** Return an OpenLayers Layer for the Vector source.
  *
  *  @param mapSource The MapSource definition from the store.
@@ -186,48 +221,21 @@ function defineSource(mapSource) {
  */
 export function createLayer(mapSource) {
     const source = new VectorSource(defineSource(mapSource));
+
+    const layer = new VectorLayer(opts);
+
+    // get the transforms for the layer
+    if(mapSource.transforms) {
+        source.on('addfeature', function(evt) {
+            const f = evt.feature;
+            f.setProperties(util.transformProperties(mapSource.transforms, f.getProperties()));
+        });
+    }
+
     const opts = {
-        source
+        source,
+        style: defineStyle(mapSource)
     };
-
-    // with vector layers each sub-layer is a style grouping
-    // in defineSource, only the FIRST layer's name is used
-    // as the WFS type name.
-    const layers = [];
-    for(const layer of mapSource.layers) {
-        const layer_def = {
-            id: layer.name,
-            // source is a contant that is used to dummy up
-            //  the Mapbox styles
-            source: 'dummy-source',
-            paint: layer.style,
-        };
-
-        // check to see if there is a filter
-        //  set on the layer.  This uses the Mapbox GL/JS
-        //  filters.
-        if(layer.filter !== null) {
-            layer_def.filter = layer.filter;
-        }
-
-        layers.push(layer_def);
-    }
-
-    // If there are any styles defined
-    //  then use them to style the layer.
-    // Otherwise this will use the built-in OL styles.
-    if(layers.length > 0) {
-        opts.style = getStyleFunction({
-            'version': 8,
-            'layers': layers,
-            'dummy-source': [
-                {
-                    'type': 'vector'
-                }
-            ]
-        }, 'dummy-source');
-    }
-
     return new VectorLayer(opts);
 }
 
@@ -259,7 +267,10 @@ export function updateLayer(map, layer, mapSource) {
 
             // update the version number
             layer.set('featuresVersion', mapSource.layers[0].featuresVersion);
-
         }
     }
+
+    // update the style effectively turns "layers"
+    // on and off on vector layers.
+    layer.setStyle(defineStyle(mapSource));
 }

--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -247,7 +247,7 @@ export function updateLayer(map, layer, mapSource) {
         // is stored in mapSource.features
         const layer_version = layer.get('featuresVersion');
         // check to see if there was an update to the features
-        if(layer_version !== mapSource.layers[0].featuresVersion) {
+        if(layer_version !== mapSource.featuresVersion) {
             // this is a bit heavy-handed strategy.
             const source = layer.getSource();
             // clear the layer without setting off events.
@@ -261,12 +261,12 @@ export function updateLayer(map, layer, mapSource) {
             });
             // bring in the new features.
             const features = output_format.readFeatures({
-                type: 'FeatureCollection', features: mapSource.layers[0].features
+                type: 'FeatureCollection', features: mapSource.features
             });
             source.addFeatures(features);
 
             // update the version number
-            layer.set('featuresVersion', mapSource.layers[0].featuresVersion);
+            layer.set('featuresVersion', mapSource.featuresVersion);
         }
     }
 

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -332,7 +332,7 @@ class Map extends Component {
         // the OL formatter requires that the typename and the schema be
         //  broken apart in order to properly format the request.
         // TODO: If this gets used elsewhere, push to a util function.
-        let type_parts = layer_name.split(':');
+        let type_parts = map_source.params.typename.split(':');
 
         // TinyOWS and GeoServer support GeoJSON, but MapServer
         //  only supports GML.
@@ -373,11 +373,8 @@ class Map extends Component {
                     // features to add
                     let js_features = (new GeoJSONFormat()).writeFeaturesObject(features).features;
 
-                    // get the transforms for the layer
-                    const transforms = mapSourceActions.getLayerByPath(this.props.store, queryLayer).transforms;
-
                     // apply the transforms
-                    js_features = util.transformFeatures(transforms, js_features);
+                    js_features = util.transformFeatures(map_source.transforms, js_features);
 
                     this.props.store.dispatch(
                         mapActions.resultsForQuery(queryId, queryLayer, false, js_features)
@@ -527,7 +524,7 @@ class Map extends Component {
         const map = this.map;
 
         // get the query service url.
-        const query_url = map_source.urls[0] + layer_name + '/query/';
+        const query_url = map_source.urls[0] + '/query/';
         util.xhr({
             url: query_url,
             method: 'get',
@@ -553,11 +550,8 @@ class Map extends Component {
                         js_features.push(js_feature);
                     }
 
-                    // get the transforms for the layer
-                    const transforms = mapSourceActions.getLayerByPath(this.props.store, queryLayer).transforms;
-
                     // apply the transforms
-                    js_features = util.transformFeatures(transforms, js_features);
+                    js_features = util.transformFeatures(map_source.transforms, js_features);
 
                     this.props.store.dispatch(
                         mapActions.resultsForQuery(queryId, queryLayer, false, js_features)

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -712,7 +712,7 @@ class Map extends Component {
             // get the features, aftre applying the query filter
             const features = util.matchFeatures(query.results[layer_path], query.filter);
             // render only those features.
-            this.props.store.dispatch(mapSourceActions.addFeatures('results', 'results', features));
+            this.props.store.dispatch(mapSourceActions.addFeatures('results', features));
         } else {
             console.error('No "results" layer has been defined, cannot do smart query rendering.');
         }
@@ -819,11 +819,11 @@ class Map extends Component {
         this.props.store.dispatch(mapActions.addSelectionFeature(json_feature));
 
         this.props.store.dispatch(
-            mapSourceActions.clearFeatures('selection', 'selection')
+            mapSourceActions.clearFeatures('selection')
         );
 
         this.props.store.dispatch(
-            mapSourceActions.addFeatures('selection', 'selection', [json_feature])
+            mapSourceActions.addFeatures('selection', [json_feature])
         );
 
     }
@@ -1060,7 +1060,7 @@ class Map extends Component {
                     const fid = evt.selected[0].getProperties()[id_prop];
                     // send the remove feature event to remove it.
                     this.props.store.dispatch(
-                        mapSourceActions.removeFeature(map_source_name, layer_name, fid)
+                        mapSourceActions.removeFeature(map_source_name, fid)
                     );
                     // clear the selected features from the tool.
                     this.drawTool.getFeatures().clear();
@@ -1086,7 +1086,7 @@ class Map extends Component {
 
                             if(id) {
                                 this.props.store.dispatch(
-                                    mapSourceActions.modifyFeatureGeometry(map_source_name, layer_name, id, geometry)
+                                    mapSourceActions.modifyFeatureGeometry(map_source_name, id, geometry)
                                 );
                             }
                         }
@@ -1117,7 +1117,7 @@ class Map extends Component {
                         let json_feature = geojson.writeFeatureObject(evt.feature);
 
                         this.props.store.dispatch(mapSourceActions.addFeatures(
-                                                     map_source_name, layer_name, [json_feature]));
+                                                     map_source_name, [json_feature]));
 
                         // drawing is finished, no longer sketching.
                         this.sketchFeature = null;

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -647,6 +647,27 @@ export function xhr(opts) {
 }
 
 
+export function transformProperties(transforms, properties) {
+    const new_properties = Object.assign({}, properties);
+
+    for(const prop in transforms) {
+        let value = properties[prop];
+        switch(transforms[prop]) {
+            case 'string':
+                value = '' + value;
+                break
+            case 'number':
+                value = parseFloat(value);
+                break;
+            default:
+                // do nothing on default.
+        }
+        new_properties[prop] = value;
+    }
+
+    return new_properties;
+}
+
 /* Convert the data type of feature properties.
  *
  * @param transforms Object of transforms to apply.
@@ -660,20 +681,7 @@ export function transformFeatures(transforms, features) {
     }
 
     for(const feature of features) {
-        for(const prop in transforms) {
-            let value = feature.properties[prop];
-            switch(transforms[prop]) {
-                case 'string':
-                    value = '' + value;
-                    break
-                case 'number':
-                    value = parseFloat(value);
-                    break;
-                default:
-                    // do nothing on default.
-            }
-            feature.properties[prop] = value;
-        }
+        feature.properties = transformProperties(transforms, feature.properties);
     }
 
     return features;

--- a/tests/gm3/components/map.test.jsx
+++ b/tests/gm3/components/map.test.jsx
@@ -115,44 +115,6 @@ describe('map compnent tests', () => {
 
         });
 
-        it('adds a vector layer', () => {
-            // these are lifted directly from gm3.Application :)
-            store.dispatch(msActions.add({
-                name: 'results',
-                urls: [],
-                type: 'vector',
-                label: 'Results',
-                opacity: 1.0,
-                queryable: false,
-                refresh: null,
-                layers: [],
-                options: {
-                    'always-on': true,
-                },
-                params: {},
-                // stupid high z-index to ensure results are
-                //  on top of everything else.
-                zIndex: 200001,
-            }));
-            store.dispatch(msActions.addLayer('results', {
-                name: 'results',
-                on: true,
-                label: 'Results',
-                selectable: true,
-                style: {
-                    'circle-radius': 4,
-                    'circle-color': '#ffff00',
-                    'circle-stroke-color': '#ffff00',
-                    'line-color': '#ffff00',
-                    'line-width': 4,
-                    'fill-color': '#ffff00',
-                    'fill-opacity': 0.25,
-                    'line-opacity': 0.25,
-                },
-                filter: []
-            }));
-        });
-
         it('adds an XYZ layer', () => {
             store.dispatch(msActions.add({
                 name: 'osm',

--- a/tests/gm3/reducers/mapSource.test.js
+++ b/tests/gm3/reducers/mapSource.test.js
@@ -1,0 +1,132 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2017 Dan "Ducky" Little
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+ /*
+CHANGE_TOOL: 'MAP_CHANGE_TOOL',
+ADD_SELECTION_FEATURE: 'MAP_ADD_SELECTION_FEATURE',
+CLEAR_SELECTION_FEATURES: 'MAP_CLEAR_SELECTION_FEATURES',
+BUFFER_SELECTION_FEATURES: 'MAP_BUFFER_SELECTION_FEATURES',
+*/
+
+import { createStore, combineReducers } from 'redux';
+
+import reducer from 'gm3/reducers/mapSource'
+import * as msActions from 'gm3/actions/mapSource'
+
+import { FEATURES } from '../sample_data';
+
+describe('test the `map` reducer', () => {
+    let store = null;
+
+    // before each test refresh the store.
+    //beforeEach(() => {
+        store = createStore(combineReducers({
+            mapSources: reducer
+        }));
+    // });
+
+    it('adds a vector layer', () => {
+        // these are lifted directly from gm3.Application :)
+        store.dispatch(msActions.add({
+            name: 'results',
+            urls: [],
+            type: 'vector',
+            label: 'Results',
+            opacity: 1.0,
+            queryable: false,
+            refresh: null,
+            layers: [],
+            options: {
+                'always-on': true,
+            },
+            params: {},
+            // stupid high z-index to ensure results are
+            //  on top of everything else.
+            zIndex: 200001,
+        }));
+        store.dispatch(msActions.addLayer('results', {
+            name: 'results',
+            on: true,
+            label: 'Results',
+            selectable: true,
+            style: {
+                'circle-radius': 4,
+                'circle-color': '#ffff00',
+                'circle-stroke-color': '#ffff00',
+                'line-color': '#ffff00',
+                'line-width': 4,
+                'fill-color': '#ffff00',
+                'fill-opacity': 0.25,
+                'line-opacity': 0.25,
+            },
+            filter: []
+        }));
+    });
+
+    it('adds features to the vector layer', () => {
+        store.dispatch(msActions.addFeatures('results', [
+            {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0,0]
+                }
+            }
+        ]));
+
+        const st = store.getState();
+        expect(st.mapSources.results.features.length).toBe(1);
+
+    });
+
+    it('removes a feature from the vector layer (by id)', () => {
+        const fid = store.getState().mapSources.results.features[0].properties._uuid;
+        store.dispatch(msActions.removeFeature('results', fid));
+
+        const st = store.getState();
+        expect(st.mapSources.results.features.length).toBe(0);
+    });
+
+    it('adds features from the parcels file', () => {
+        store.dispatch(msActions.addFeatures('results', FEATURES));
+
+        const st = store.getState();
+        expect(st.mapSources.results.features.length).toBe(10);
+    });
+
+    it('remove features by filter', () => {
+        store.dispatch(msActions.removeFeatures('results', [['<', 'emv_total', 300000]]));
+        const st = store.getState();
+        expect(st.mapSources.results.features.length).toBe(3);
+    });
+
+    it('clears all the features', () => {
+        store.dispatch(msActions.clearFeatures('results'));
+        const st = store.getState();
+        expect(st.mapSources.results.features.length).toBe(0);
+    });
+
+
+
+});


### PR DESCRIPTION
1. typename is no longer inferred for WFS layers,
   it's a required parameter.
2. ags-vector layers must now specify the *full* path
   instead of inferring it from the layer name.
3. `layer`s in vector layers are now basically for styling.
   They work with the list of features that have been returned
   from the vector source.  The mapbook hsa been updated to show
   "expensive" parcels as an example.
4. Properties are now transformed when injested from vector sources
   as well as from queries.  This allows the user to force the datatype
   of a feature property.
5. The mapbook and app.js has also been updated in the desktop example
   to use "common names" instead of direct layer names to prevent
   confusion and conflation.