### PR TITLE
Major bug fixes for printing

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -200,6 +200,7 @@
 		<url>https://services.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer</url>
 		<layer name="NatGeo_World_Map"/>
 		<param name="FORMAT" value="png"/>
+        <param name="cross-origin" value="anonymous"/>
 	</map-source>
 
     <map-source name="ags-vector-dc16" type="ags-vector">

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -361,18 +361,18 @@
 		<url>https://a.tile.openstreetmap.org/{z}/{x}/{y}.png</url>
 		<url>https://b.tile.openstreetmap.org/{z}/{x}/{y}.png</url>
 		<url>https://c.tile.openstreetmap.org/{z}/{x}/{y}.png</url>
+
+        <param name="cross-origin" value="anonymous"/>
 	</map-source>
 
-	<map-source name="wmflabs" type="xyz">
+	<map-source name="wmflabs" type="xyz" printable="false">
 		<layer name="osm_black_n_white">
 			<legend type="html"><![CDATA[
 			Data &copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> Contributors.  Tiles by Wikimedia Foundation Labs.
 			<br><br>
 			]]></legend>
 		</layer>
-		<url>http://a.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png</url>
-		<url>http://b.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png</url>
-		<url>http://c.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png</url>
+		<url>https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png</url>
 	</map-source>
 
 <!--	<map-source name="thunderforest" type="xyz">
@@ -455,8 +455,11 @@
 			<layer title="USGS DOQs" src="usgs/usgs_imagery" show-legend="false" legend="false" fade="true" unfade="true"/>
 			<layer title="USGS Topo Quads" src="usgs/usgs_topo" show-legend="false" legend="false" fade="true" unfade="true"/>
 			<layer title="ArcGIS 9.3 Rest Example" src="ags/NatGeo_World_Map" show-legend="false" legend="false" fade="true" unfade="true"/>
+            <!-- These layres are commented out until a user enabled bing
+              -  with an appropriate key.
 			<layer title="Bing Roads" src="bing/roads" show-legend="false" legend="false" fade="true" unfade="true"/>
 			<layer title="Bing Aerials" src="bing/aerials" show-legend="false" legend="false" fade="true" unfade="true"/>
+            -->
 		</group>
 	</catalog>
 

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -165,6 +165,8 @@ export function addFromXml(xml, config) {
         opacity: xml.getAttribute('opacity'),
         zIndex: xml.getAttribute('z-index'),
         queryable: util.parseBoolean(xml.getAttribute('queryable'), true),
+        // assume layers are printable
+        printable: util.parseBoolean(xml.getAttribute('printable'), true),
         refresh: null,
         layers: [],
         params: {}
@@ -401,12 +403,15 @@ function isMapSourceActive(mapSource) {
 /** Get the list of all map-sources which have a
  *  layer that is on.
  */
-export function getActiveMapSources(store) {
+export function getActiveMapSources(store, onlyPrintable = false) {
     let map_sources = store.getState().mapSources;
     let active = [];
+    const all_maps = !onlyPrintable;
     for(let ms in map_sources) {
         if(isMapSourceActive(map_sources[ms])) {
-            active.push(ms);
+            if(all_maps || map_sources[ms].printable) {
+                active.push(ms);
+            }
         }
     }
     return active;

--- a/src/gm3/components/layers/ags.js
+++ b/src/gm3/components/layers/ags.js
@@ -33,7 +33,13 @@ import ArcRestSource from 'ol/source/tilearcgisrest';
  *
  */
 function defineSource(mapSource) {
+    let cx_origin = null;
+    if(mapSource.params['cross-origin']) {
+        cx_origin = mapSource.params['cross-origin'];
+    }
+
     return {
+        crossOrigin: cx_origin,
         url: mapSource.urls[0]
     }
 }

--- a/src/gm3/components/layers/xyz.js
+++ b/src/gm3/components/layers/xyz.js
@@ -35,8 +35,13 @@ import TileLayer from 'ol/layer/tile';
  *
  */
 function defineSource(mapSource) {
+    let cx_origin = null;
+    if(mapSource.params['cross-origin']) {
+        cx_origin = mapSource.params['cross-origin'];
+    }
+
     return {
-        crossOrigin: 'anonymous',
+        crossOrigin: cx_origin,
         urls: mapSource.urls
     }
 }

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -729,7 +729,8 @@ class Map extends Component {
      */
     refreshMapSources() {
         // get the list of current active map-sources
-        let active_map_sources = mapSourceActions.getActiveMapSources(this.props.store);
+        const print_only = (this.props.printOnly === true);
+        let active_map_sources = mapSourceActions.getActiveMapSources(this.props.store, print_only);
 
         // annoying O(n^2) iteration to see if the mapsource needs
         //  to be turned off.

--- a/src/gm3/components/print/printImage.jsx
+++ b/src/gm3/components/print/printImage.jsx
@@ -82,6 +82,7 @@ class PrintImage extends Component {
         return (
             <div style={image_style} id={this.state.mapId}>
                 <Map store={this.props.store} center={center} resolution={rez}
+                     printOnly={true}
                      mapRenderedCallback={() => { this.mapRendered() }}
                 />
             </div>

--- a/src/gm3/reducers/mapSource.js
+++ b/src/gm3/reducers/mapSource.js
@@ -166,7 +166,11 @@ export default function mapSource(state = [], action) {
         case MAPSOURCE.SET_TEMPLATE:
             return setLayerAttribute(state, action);
         case MAPSOURCE.ADD:
-            new_elem[action.mapSource.name] = action.mapSource;
+            new_elem[action.mapSource.name] = Object.assign({
+                params: {},
+                printable: true,
+                queryable: false
+            }, action.mapSource);
             return Object.assign({}, state, new_elem);
         case MAPSOURCE.SET_Z:
             const new_z_ms = {};


### PR DESCRIPTION
1. Added a `printable` attributes to map-sources.
   This defaults to true but is set to false for the WMF Labs tiles
   which do not support cross origin printing. Note: this may work
   with some apache header settings but I haven't tested it yet
   and not wanting to enforce web-server rules I made the decision to
   make this just not-printable.

2. Commented out Bing layers.
   These don't work without a key from Bing. When the tutorials
   are published they will include how to add back in Bing layers.

3. Made specifying the cross-origin parameter more clear.
   OpenLayers will set a CORS header when given a little information,
   the ol.source.OSM class sets this to anonymous by default but I
   didn't want to map any additional layer type when XYZ layers will
   work fine with the additional parameter.  This can be further
   built-out to include layers which require authorization.

4. Similar to the issues with OSM layers, this adds cross-origin
support to AGS raster layers.

5. There were tests failing due to "params" being undefined
for map-source's.  This ensures other tests can rely on
map-source.params existing.  It also sets a couple of other
handy defaults.

refs: #160 
