### PR TITLE
Better handling of "tainted" canvases.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,16 +125,15 @@ module.exports = function(grunt) {
 
         'webpack-dev-server': {
             options: {
-                webpack: webpackConfig,
-                publicPath: "./"
+                webpack: webpackConfig
             },
-            start: Object.assign({}, webpackConfig.devServer)
+            start: Object.assign({keepAlive: true}, webpackConfig.devServer)
         }
     });
 
     grunt.task.registerTask('lint', ['lintless', 'eslint']);
 
-    grunt.task.registerTask('serve', ['webpack-dev-server:start', 'watch']);
+    grunt.task.registerTask('serve', ['webpack-dev-server:start']);
 
     // update the css and fonts.
     grunt.task.registerTask('build-css', ['less:build', 'copy:fonts']);

--- a/src/gm3/components/print/printImage.jsx
+++ b/src/gm3/components/print/printImage.jsx
@@ -55,7 +55,11 @@ class PrintImage extends Component {
             if(canvas.length > 0) {
                 // other options:
                 // canvas.toDataURL('image/jpeg', quality)
-                return canvas[0].toDataURL('image/png');
+                try {
+                    return canvas[0].toDataURL('image/png');
+                } catch(error) {
+                    return 'err';
+                }
             }
         }
         return '';

--- a/src/gm3/components/print/printPreviewImage.jsx
+++ b/src/gm3/components/print/printPreviewImage.jsx
@@ -51,8 +51,25 @@ class PrintPreviewImage extends Component {
             width: '100%'
         };
 
-        if(this.props.print.printData) {
-            return (<img style={image_style} src={ this.props.print.printData }/>);
+        const print_data = this.props.print.printData;
+
+        if(print_data) {
+            if(print_data.substring(0, 3) === 'err') {
+                return (<div className='error-message'>
+                    There was an error generating the print image.<br/>
+                    This is likely due to a cross-origin/CORS error with a map-source
+                    which is being served from an external server. Check:
+                    <ol>
+                     <li>The server supports cross-origin requests.</li>
+                     <li>That the cross-origin param is set in the mapbook.</li>
+                     <li>If the server does not support cross-origin requests, set the map-source's printable
+                         attribute to false.</li>
+                    </ol>
+                </div>);
+            } else {
+                return (<img style={image_style} src={print_data}/>);
+            }
+
         }
         return false;
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,7 @@ module.exports = {
         libraryTarget: 'umd'
     },
     devServer: {
+        publicPath: '/examples/geomoose/dist',
         contentBase: './',
         port: 4000,
         proxy: [


### PR DESCRIPTION
Misconfigured raster sources can cause the canvas to throw
an error.  The dialog is now improved to detect that and tell the
user that there may be a misconfiguration.

addresses #151 

side-effects: depends on PR #163 