### PR TITLE
Don't package useless source map.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -32,3 +32,7 @@ geomoose*.tgz
 # Results of building
 # Note: this should be ignored by git but by not npm
 # dist/
+
+# Don't package useless source map (the source URLs are all webpack relative
+# which can't resolve to anything in production.)
+dist/geomoose.min.js.map


### PR DESCRIPTION
The source URLs in geomoose.min.js.map are all webpack relative
which can't resolve to anything in production.  This reduces the
output pack size from 8.5MB to 5.9MB.

Note: This doesn't change the embedded source map in geomoose.js.