### PR TITLE
Attempt to make identify look less ugly.

### DIFF
--- a/examples/desktop/app.css
+++ b/examples/desktop/app.css
@@ -141,3 +141,10 @@ body {
         left: 350px;
     }
 }
+
+/* Example of how to add CSS for a specific layer's
+ * identify results.
+ */
+.feature-class.pipelines {
+    background-color: #4894ff;
+}

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -140,15 +140,16 @@
 		<layer name="pipelines" status="off">
             <template name="identify"><![CDATA[
             <div>
-                Pipeline<br>
-                <div>
-                    <b>Name:</b> {{ properties.name }}
+                <div class="feature-class pipelines">
+                Pipeline
                 </div>
-                <div>
-                    <b>Owner:</b> {{ properties.owner }}
+                <div class="item">
+                    <label>Name:</label> {{ properties.name }}
+                </div>
+                <div class="item">
+                    <label>Owner:</label> {{ properties.owner }}
                 </div>
             </div>
-            <br>
             ]]></template>
         </layer>
 		<param name="FORMAT" value="image/png"/>

--- a/src/less/results.less
+++ b/src/less/results.less
@@ -119,3 +119,19 @@
         content: @fa-var-filter;
     }
 }
+
+.feature-class {
+    background-color: #6dbe45;
+    font-weight: bold;
+    margin-top: 3px;
+    padding: 2px;
+}
+
+.item {
+    padding: 1px;
+}
+
+.item label {
+    display: inline-block;
+    margin-top: 2px;
+}


### PR DESCRIPTION
1. Cleaned up the template for pipelines.
2. Added an example of how to tailor the CSS + the
   template to do something specific for a given layer (pipelines)
3. Cleaned up the LESS/CSS to make the identify results a bit shorter
   and a bit better looking.