### PR TITLE
Fix for single-identify returns.

### DIFF
--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -187,6 +187,7 @@ class Map extends Component {
             // TODO: Allow the configuration to specify GML vs GeoJSON,
             //       but GeoMoose needs a real feature returned.
             let params = {
+                'FEATURE_COUNT': 1000,
                 'QUERY_LAYERS': util.getLayerName(queryLayer),
                 'INFO_FORMAT': 'application/vnd.ogc.gml'
             };


### PR DESCRIPTION
Without FEATURE_COUNT set only one feature per layer would be returned.

This now lets up to 1000 features be returned.

refs: #176 