### PR TITLE
Fixed two identify bugs.

### DIFF
--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -508,9 +508,15 @@ export function getVisibleLayers(store) {
  *  These layers are a subset of visible layers.
  *
  */
-export function getQueryableLayers(store) {
+export function getQueryableLayers(store, filter) {
     const match_fn = function(ms, layer) {
-        return (isQueryable(ms, layer) && isVisible(ms, layer));
+        let template_filter_pass = true;
+        if(filter && filter.withTemplate) {
+            const tpl_name = filter.withTemplate;
+            const templates = layer.templates;
+            template_filter_pass = (templates && typeof templates[tpl_name] !== 'undefined');
+        }
+        return (template_filter_pass && isQueryable(ms, layer) && isVisible(ms, layer));
     }
     return matchLayers(store, match_fn);
 }

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -480,8 +480,8 @@ class Application {
      *
      *  @returns an array of layer paths.
      */
-    getQueryableLayers() {
-        return getQueryableLayers(this.store);
+    getQueryableLayers(filter) {
+        return getQueryableLayers(this.store, filter);
     }
 
     /** zoom to an extent

--- a/src/services/identify.js
+++ b/src/services/identify.js
@@ -68,7 +68,7 @@ function IdentifyService(Application, options) {
      */
     this.query = function(selection, fields) {
         // get the list of visible layers
-        var visible_layers = Application.getQueryableLayers();
+        var visible_layers = Application.getQueryableLayers({withTemplate: 'identify'});
 
         // This will dispatch the query.
         // Application.dispatchQuery is used to query a set of map-sources


### PR DESCRIPTION
1. There are situations in which MapServer returns a 200 status code
   but the "response" is not valid. This was causing a dead end for
   identifying layers that has now been fixed.
2. Added a "filter" to the getQueryableLayers function which will
   allow services to defined a required template before querying them.
   e.g. `getQueryableLayers({withTemplate: 'identify'})`.