### PR TITLE
Fixed missing show-legend support.

### DIFF
--- a/src/gm3/actions/catalog.js
+++ b/src/gm3/actions/catalog.js
@@ -85,7 +85,7 @@ function parseLayer(store, layerXml) {
     let new_layer = {
         id: layerXml.getAttribute('uuid'),
         label: layerXml.getAttribute('title'),
-        legend: true,
+        legend: util.parseBoolean(layerXml.getAttribute('show-legend'), true),
         src: [],
         favorite: false,
         refreshEnabled: false,


### PR DESCRIPTION
`show-legend` will ensure a legend is not displayed for a layer.

This was in 2.x and is now in 3.0.0.