### PR TITLE
CSS Tweaks and new LayersList Control

### DIFF
--- a/examples/desktop/app.css
+++ b/examples/desktop/app.css
@@ -142,6 +142,13 @@ body {
     }
 }
 
+.feature-class {
+    background-color: #CFE7B3;
+    padding: 2px;
+    font-weight: bold;
+    margin-top: 5px;
+}
+
 /* Example of how to add CSS for a specific layer's
  * identify results.
  */

--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -65,11 +65,7 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     app.registerService('identify', IdentifyService);
     app.registerService('search', SearchService);
     app.registerService('select', SelectService, {
-        queryLayers: [
-            {value: 'vector-parcels/parcels', label: 'Parcels'},
-            //{value: 'ags-vector-dc20/roads', label: 'Dakota County Streets'},
-            {value: 'ags-vector-dc16/railroads', label: 'Dakota County Rail'}
-        ]
+        defaultLayer: 'vector-parcels/parcels'
     });
 
     // This uses the OpenStreetMap Nominatim geocoder,

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -508,7 +508,7 @@ export function getVisibleLayers(store) {
  *  These layers are a subset of visible layers.
  *
  */
-export function getQueryableLayers(store, filter, options = {}) {
+export function getQueryableLayers(store, filter = {}, options = {}) {
     // when visible is set to true, then any visibility will
     //  be false and the isVisible call will be evaluated.
     const req_visible = (typeof filter.requireVisible === 'undefined') ? true : filter.requireVisible;
@@ -518,7 +518,7 @@ export function getQueryableLayers(store, filter, options = {}) {
             let template_names = filter.withTemplate;
             // coerce the templates into an array
             if(typeof template_names === 'string') {
-                template_names = [template_names,];
+                template_names = [template_names, ];
             }
 
             template_filter_pass = false;

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -508,15 +508,27 @@ export function getVisibleLayers(store) {
  *  These layers are a subset of visible layers.
  *
  */
-export function getQueryableLayers(store, filter) {
+export function getQueryableLayers(store, filter, options = {}) {
+    // when visible is set to true, then any visibility will
+    //  be false and the isVisible call will be evaluated.
+    const req_visible = (typeof filter.requireVisible === 'undefined') ? true : filter.requireVisible;
     const match_fn = function(ms, layer) {
         let template_filter_pass = true;
         if(filter && filter.withTemplate) {
-            const tpl_name = filter.withTemplate;
+            let template_names = filter.withTemplate;
+            // coerce the templates into an array
+            if(typeof template_names === 'string') {
+                template_names = [template_names,];
+            }
+
+            template_filter_pass = false;
             const templates = layer.templates;
-            template_filter_pass = (templates && typeof templates[tpl_name] !== 'undefined');
+            for (let x = 0, xx = template_names.length; x < xx && !template_filter_pass; x++) {
+                const tpl_name = template_names[x];
+                template_filter_pass = (templates && typeof templates[tpl_name] !== 'undefined');
+            }
         }
-        return (template_filter_pass && isQueryable(ms, layer) && isVisible(ms, layer));
+        return (template_filter_pass && isQueryable(ms, layer) && (!req_visible || isVisible(ms, layer)));
     }
     return matchLayers(store, match_fn);
 }

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -91,6 +91,8 @@ class Application {
         this.store.subscribe(() => { this.shouldUiUpdate(); });
 
         this.dialogs = {};
+
+        this.showWarnings = (config.showWarnings === true);
     }
 
     registerService(serviceName, serviceClass, options) {
@@ -411,7 +413,11 @@ class Application {
                     }
                 } else {
                     template_contents = null;
-                    console.info('Failed to find template.', path, template_name);
+                    // only show warnings when the application is
+                    //  configured to do so.
+                    if(this.showWarnings) {
+                        console.info('Failed to find template.', path, template_name);
+                    }
                 }
             }
 

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -65,7 +65,7 @@ import Map from './components/map';
 
 class Application {
 
-    constructor(config) {
+    constructor(config = {}) {
         this.elements = [];
 
         this.services = {};

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -664,7 +664,6 @@ class Map extends Component {
                 // ".ck" = "cache killer"
                 params['.ck'] = (new Date()).getMilliseconds();
                 wms_src.updateParams(params);
-                console.log('refreshed wms layer', mapSource.name);
                 // this.olLayers[mapSource.name].getSource().refresh();
                 break;
             default:
@@ -681,7 +680,6 @@ class Map extends Component {
             // refresh is stored in seconds, multiplying by 1000
             //  converts ito the milliseconds expected by setInterval.
             this.intervals[mapSource.name] = setInterval(() => {
-                console.log('REFRESH', mapSource.name);
                 this.refreshLayer(mapSource);
             }, mapSource.refresh * 1000);
         }

--- a/src/gm3/components/serviceInputs/layersList.jsx
+++ b/src/gm3/components/serviceInputs/layersList.jsx
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2017 Dan "Ducky" Little
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React from 'react';
+import SelectInput from './select';
+
+import { getQueryableLayers, getLayerByPath } from '../../actions/mapSource';
+
+
+export default class LayersListInput extends SelectInput {
+    getOptions() {
+        // default to an empty layers list.
+        let layers = [];
+        // if layers are specified in a list then just use
+        //   that list of paths.
+        if(this.props.field.filter.layers) {
+            layers = this.props.field.filter.layers;
+        // otherwise assume this is used for querying and get the list of
+        //  queryable layers that match the filter.
+        } else {
+            layers = getQueryableLayers(this.props.store, this.props.field.filter);
+        }
+
+        const options = [];
+        for(let i = 0, ii = layers.length; i < ii; i++) {
+            const layer = getLayerByPath(this.props.store, layers[i]);
+            options.push({
+                value: layers[i],
+                label: layer.label,
+            });
+        }
+        return options;
+    }
+}

--- a/src/gm3/components/serviceInputs/select.jsx
+++ b/src/gm3/components/serviceInputs/select.jsx
@@ -33,14 +33,22 @@ export default class SelectInput extends TextInput {
         return (<option key={opt.value} value={opt.value}>{opt.label}</option>);
     }
 
+    getOptions() {
+        return this.props.field.options;
+    }
+
     render() {
         const id = this.getId();
+        const options = this.getOptions();
+        if(typeof this.props.field.default === 'undefined') {
+            this.onChange({target: {value: options[0].value}});
+        }
 
         return (
             <div className='service-input select'>
                 <label htmlFor={ 'input-' + id }>{ this.props.field.label }</label>
                 <select id={ 'input-' + id} value={this.state.value} onChange={this.onChange}>
-                { this.props.field.options.map(this.renderOption) }
+                { options.map(this.renderOption) }
                 </select>
             </div>
         );

--- a/src/gm3/components/serviceManager.jsx
+++ b/src/gm3/components/serviceManager.jsx
@@ -48,6 +48,7 @@ import DrawTool from './drawTool';
 import TextInput from './serviceInputs/text';
 import SelectInput from './serviceInputs/select';
 import LengthInput from './serviceInputs/length';
+import LayersInput from './serviceInputs/layersList';
 
 import MeasureTool from './measure';
 
@@ -467,14 +468,17 @@ class ServiceManager extends Component {
     }
 
     getServiceField(i, field, value) {
+        const key = `field-${i}`;
         switch(field.type) {
             case 'select':
-                return (<SelectInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
+                return (<SelectInput setValue={this.onServiceFieldChange} key={key} field={field} value={value}/>);
             case 'length':
-                return (<LengthInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
+                return (<LengthInput setValue={this.onServiceFieldChange} key={key} field={field} value={value}/>);
+            case 'layers-list':
+                return (<LayersInput setValue={this.onServiceFieldChange} store={this.props.store} key={key} field={field} value={value}/>);
             case 'text':
             default:
-                return (<TextInput setValue={this.onServiceFieldChange} key={'field-' + i} field={field} value={value}/>);
+                return (<TextInput setValue={this.onServiceFieldChange} key={key} field={field} value={value}/>);
         }
     }
 

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -32,7 +32,7 @@
             content: @fa-var-circle-o;
         }
     }
-        
+
 }
 
 .radio-option.selected,.draw-tool.selected {
@@ -55,7 +55,7 @@
             background: none;
             cursor: pointer;
         }
-        
+
         .go-button {
             float: right;
         }
@@ -82,15 +82,20 @@
     }
 
     label {
-        display: block;
-        font-weight: bold;
-        margin-top: 7px;
+            font-weight: bold;
+    }
+
+    .service-input {
+        label {
+            display: block;
+            margin-top: 7px;
+        }
     }
 
     input[type='text'] {
         width: 90%;
     }
-    
+
     .service-input.select {
         select {
             width: 90%;

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -73,11 +73,16 @@ function SelectService(Application, options) {
 
     /** User input fields, select allows choosing a layer */
     this.fields = [{
-        type: 'select',
+        type: 'layers-list',
         name: 'layer',
         label: 'Query Layer',
-        default: options.queryLayers ? options.queryLayers[0].value : '',
-        options: options.queryLayers ? options.queryLayers : []
+        default: options.defaultLayer,
+        filter: {
+            // do not require the layer be visible to select it.
+            requireVisible: false,
+            // but require it have a select template.
+            withTemplate: ['select', 'select-header']
+        }
     }];
 
     /** Alow shapes to be buffered. */


### PR DESCRIPTION
1. Added new `layers-list` type select that can be used
   to generate a list of layers based on template filters.
2. Cleaned up and enhanced some of the default desktop app CSS.