### PR TITLE
Added support for WFS + GeoJSON

### DIFF
--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -48,11 +48,12 @@ function defineSource(mapSource) {
         let format = GML2Format;
         let output_format = 'text/xml; subtype=gml/2.1.2';
 
-        if(mapSource.params.outputFormat
-          && mapSource.params.outputFormat.indexOf('json') >= 0) {
+        if(mapSource.params.outputFormat) {
+            output_format = mapSource.params.outputFormat;
+        }
 
+        if(output_format.toLowerCase().indexOf('json') >= 0) {
             format = GeoJSONFormat;
-            output_format = 'application/json';
         }
 
         return {

--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -45,8 +45,18 @@ import getStyleFunction from 'mapbox-to-ol-style';
 function defineSource(mapSource) {
     if(mapSource.type === 'wfs') {
         // add a wfs type source
+        let format = GML2Format;
+        let output_format = 'text/xml; subtype=gml/2.1.2';
+
+        if(mapSource.params.outputFormat
+          && mapSource.params.outputFormat.indexOf('json') >= 0) {
+
+            format = GeoJSONFormat;
+            output_format = 'application/json';
+        }
+
         return {
-            format: new GML2Format({}),
+            format: new format({}),
             projection: 'EPSG:4326',
             url: function(extent) {
                 if(typeof(mapSource.params.typename) === 'undefined') {
@@ -55,7 +65,7 @@ function defineSource(mapSource) {
 
                 let url_params = Object.assign({}, mapSource.params, {
                     'srsname': 'EPSG:3857',
-                    'outputFormat': 'text/xml; subtype=gml/2.1.2',
+                    'outputFormat': output_format,
                     'service': 'WFS',
                     'version': '1.1.0',
                     'request': 'GetFeature',

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -336,10 +336,8 @@ class Map extends Component {
 
         // check for the output_format based on the params
         let output_format = 'text/xml; subtype=gml/2.1.2';
-        if(map_source.params.outputFormat
-           && map_source.params.outputFormat.toLowerCase().indexOf('json') >= 0) {
-            // ask for JSON instead.
-            output_format = 'application/json';
+        if(map_source.params.outputFormat) {
+            output_format = map_source.params.outputFormat;
         }
 
         let feature_request = new WFSFormat().writeGetFeature({
@@ -357,11 +355,12 @@ class Map extends Component {
         let wfs_url = map_source.urls[0] + '?' + util.formatUrlParameters(map_source.params);;
 
         const map = this.map;
+        const is_json_like = (output_format.toLowerCase().indexOf('json'));
 
         util.xhr({
             url: wfs_url,
             method: 'post',
-            contentType: output_format === 'application/json' ? 'json' : 'text/xml',
+            contentType: is_json_like ? 'json' : 'text/xml',
             data: wfs_query_xml,
             success: (response) => {
                 // not all WMS services play nice and will return the
@@ -369,7 +368,7 @@ class Map extends Component {
                 if(response) {
                     // place holder for features to be added.
                     let js_features = [];
-                    if(output_format === 'application/json') {
+                    if(is_json_like) {
                         js_features = response.features;
                     } else {
                         let features = [];


### PR DESCRIPTION
1. Added the ability to load a map using the GeoJSON return.
2. Updated queries to switch between XML and JSON.

To have WFS queries return GeoJSON set the outputFormat parameter
to 'application/json'.  E.G.:

```xml
<map-source ...>
    <param name="outputFormat" value="application/json" />
</map-source>
```