### PR TITLE
Upload dialog enhancements

### DIFF
--- a/src/gm3/components/serviceManager.jsx
+++ b/src/gm3/components/serviceManager.jsx
@@ -191,7 +191,7 @@ class ServiceManager extends Component {
                 html_contents = service.resultsAsHtml(queryId, query);
             }
         } else {
-            html_contents = "<i class='fa fa-spin fa-refresh'></i>";
+            html_contents = "<i class='service spinner'></i>";
         }
 
         return {__html: html_contents};

--- a/src/less/gm3.less
+++ b/src/less/gm3.less
@@ -87,3 +87,12 @@
     padding: 5px;
     font-size: 10pt;
 }
+
+.spinner {
+    .fa;
+    .fa-spin;
+
+    &:before {
+        content: @fa-var-refresh;
+    }
+}


### PR DESCRIPTION
1. Normalized the CSS for a progress spinner into the 'spinner'
   class name.
2. Spinner is now used by the service manager tab for loading.
3. Upload dialog now tracks its own progress. It will also show
   the number of features uploaded to the layer when finished.
4. Errors are no longer silent. But it is a pretty standard
   "something went wrong" error message.