### PR TITLE
Fixing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,37 @@
 #
-# (c) 2017 Dan "Ducky" Little
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2017 Dan "Ducky" Little
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 #
 dist: trusty
 language: node_js
 node_js:
     - "node"
 
+# setup some solid deps.
+
 # ensure the code lints clean.
 before_script:
+    - sudo apt-get -qq update
+    - sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
+    - npm install canvas
     - grunt lint

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -61,8 +61,6 @@ import Mark from 'markup-js';
 
 import * as util from './util';
 
-import Map from './components/map';
-
 class Application {
 
     constructor(config = {}) {


### PR DESCRIPTION
1. Fixed travis to include the `canvas` module for testing.

   OpenLayers is using document.createElement('CANVAS') to create
   a dummy tile in the background. This causes issues within the
   test framework as jsdom does not implement the Canvas API fully
   without using the npm canvas module.

   That module is onerous to install on Windows so I have not made
   it a requirement in the package.json as this time.

2. Removed an unused inclusion of the Map component from Application
   which was causing that package to fail though it was not causing
   errors.