### PR TITLE
Add reminder that WFS requires typename in map-source

### DIFF
--- a/docs/howto/add-select.md
+++ b/docs/howto/add-select.md
@@ -39,6 +39,8 @@ the layer to be used for select:
 1. In `<map-source ...> `, `type="mapserver-wfs"`: WFS is the OGC Web Feature Serice.
 
    WFS servers emit actual vector features definitions and not rendered maps.
+   
+   You must have a `<param name="typename" ...>` in the `<map-source ...>` for the wfs to be valid
 
 2. In `<layer ...>`, `selectable="true"`: This tells GeoMoose the layer can
    be used for selections.
@@ -46,3 +48,4 @@ the layer to be used for select:
 3. Inside of `<layer...>` there is a `<template name="select">`: This will be the template
    used by GeoMoose to render features that have been selected. If the template is not
    present then the layer will not make itself available to select.
+   


### PR DESCRIPTION
Not having this in a map-source that you want to be select-able will cause the WFS to throw an error.