### PR TITLE
Fix for broken zoom-to issue.

### DIFF
--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -503,7 +503,7 @@ class Application {
      *
      */
     zoomTo(lon, lat, resolution) {
-        this.store.dispatch(mapActions.move({lon, lat}, resolution));
+        this.store.dispatch(mapActions.move([lon, lat], resolution));
     }
 
     /** Generic bridge to the application's store's dispatch function.

--- a/tests/gm3/application.test.js
+++ b/tests/gm3/application.test.js
@@ -108,6 +108,10 @@ describe('application api calls', () => {
             center: [0,0],
             resolution: 100
         });
+
+        const map_view = app.store.getState().map;
+        expect(map_view.center).toEqual([0, 0]);
+        expect(map_view.resolution).toBe(100);
     });
 
     it('adds a projection', () => {
@@ -117,4 +121,11 @@ describe('application api calls', () => {
         });
     });
 
+    it('zooms to a location', () => {
+        app.zoomTo(1000, 1000, 200);
+
+        const map_view = app.store.getState().map;
+        expect(map_view.center).toEqual([1000, 1000]);
+        expect(map_view.resolution).toBe(200);
+    });
 });


### PR DESCRIPTION
Previous version was passing in {lon, lat} when it should've
been [lon, lat]. This is likely a cruft that was never tested.

refs: #214