### PR TITLE
Fix babel deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "test": "tests"
   },
   "devDependencies": {
-    "babel": "~6.5.2",
     "babel-cli": "~6.14.0",
     "babel-core": "~6.14.0",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Note: there is still:
```
npm WARN deprecated babel-preset-es2015@6.14.0:   Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
```

Following the recommendation of replacing `babel-preset-es2015` with `babel-preset-env` breaks the build with multiple instances of:
```
Module build failed: ReferenceError: [BABEL] ./gm3/src/index.js: Unknown option: foreign.__esModule. Check out http://babeljs.io/docs/usage/options/ for more info
```

I don't know where __esModule is coming from.  preset-env is supposed to be equivalent to es2015,es2016,es2017,es-latest.