### PR TITLE
fix for setting the default value when undefined

### DIFF
--- a/src/gm3/components/serviceInputs/select.jsx
+++ b/src/gm3/components/serviceInputs/select.jsx
@@ -37,12 +37,16 @@ export default class SelectInput extends TextInput {
         return this.props.field.options;
     }
 
-    render() {
-        const id = this.getId();
+    componentWillMount() {
         const options = this.getOptions();
         if(typeof this.props.field.default === 'undefined') {
             this.onChange({target: {value: options[0].value}});
         }
+    }
+
+    render() {
+        const id = this.getId();
+        const options = this.getOptions();
 
         return (
             <div className='service-input select'>

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -78,7 +78,7 @@ function SelectService(Application, options) {
         label: 'Query Layer',
         default: options.defaultLayer,
         filter: {
-            // do not require the layer be visible to select it.
+            // ensure that the layer is visible to prevent confusion.
             requireVisible: true,
             // but require it have a select template.
             withTemplate: ['select', 'select-header']

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -72,14 +72,14 @@ function SelectService(Application, options) {
     this.keepAlive = false;
 
     /** User input fields, select allows choosing a layer */
-    this.fields = [{
+    this.fields = options.fields || [{
         type: 'layers-list',
         name: 'layer',
         label: 'Query Layer',
         default: options.defaultLayer,
         filter: {
             // do not require the layer be visible to select it.
-            requireVisible: false,
+            requireVisible: true,
             // but require it have a select template.
             withTemplate: ['select', 'select-header']
         }


### PR DESCRIPTION
When defaultValue is undefined for a select, it was setting the
first value as the default but was during the render() cycle
which was causing an infinite loop.

refs: #237 