### PR TITLE
Created new 'query-as' attribute for layers.

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -70,9 +70,7 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
             {type: 'text', label: 'Station city', name: 'Dak_GIS__4'}
         ]
     });
-    app.registerService('select', SelectService, {
-        defaultLayer: 'vector-parcels/parcels'
-    });
+    app.registerService('select', SelectService);
 
     // This uses the OpenStreetMap Nominatim geocoder,
     // there is also a BingGeocoder service, but requires

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -70,7 +70,6 @@
                 "line-width" : 2
             }
             ]]></style>
-            <template name="identify" src="./templates/parcels.html" />
             <template name="search"><![CDATA[
                 <div class="search-result">
                     <div class="search-label">
@@ -193,19 +192,9 @@
 
     <map-source name="parcels" type="mapserver" up="true" down="true" title="Parcels">
         <file>./demo/parcels/parcels.map</file>
-        <layer name="parcels" status="on">
-            <template name="identify"><![CDATA[
-                <div class="identify-result">
-                    <div class="feature-class">Parcel</div>
-                    <div class="item"><label>PIN:</label> {{ properties.PIN }}</div>
-                    <div class="item"><label>Owner Name:</label> {{ properties.OWNER_NAME }}</div>
-                    <div class="item">
-                        <label>Est. Market Value:</label> <i>{{ properties.EMV_TOTAL }}</i>
-                    </div>
-                    <div class="item"><label>Acres:</label> {{ properties.ACRES_POLY }}</div>
-                </div>
-            ]]></template>
-        </layer>
+        <layer name="parcels" status="on" query-as="vector-parcels/parcels">
+            <template name="identify" src="./templates/parcels.html" />
+                    </layer>
         <layer name="parcels_points"/>
         <param name="FORMAT" value="image/png"/>
         <!-- this is used only for testing the group-functionality -->

--- a/examples/desktop/templates/parcels.html
+++ b/examples/desktop/templates/parcels.html
@@ -1,5 +1,5 @@
 <div class="identify-result">
-    <div class="feature-class">Vector Parcel (remote template)</div>
+    <div class="feature-class">Parcel (remote template)</div>
     <div class="item"><label>PIN:</label> {{ properties.PIN }}</div>
     <div class="item"><label>Owner Name:</label> {{ properties.OWNER_NAME }}</div>
     <div class="item">


### PR DESCRIPTION
'query-as' is a list of paths (colon delimited) which are used
for querying in the place of a specific layer.  This allows a
raster map-source (e.g. WMS) to transparently switch to vector
sources (e.g. WFS) when performing a select or search operation.

refs: #240 