### PR TITLE
zoomTo now zooms to a zoom level and not a resolution.

### DIFF
--- a/src/gm3/actions/map.js
+++ b/src/gm3/actions/map.js
@@ -28,10 +28,11 @@
 
 import { MAP } from '../actionTypes';
 
-export function move(center, resolution) {
+export function move(center, zoom) {
     return {
         type: MAP.MOVE,
-        center, resolution
+        center,
+        zoom,
     }
 }
 

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -31,6 +31,7 @@
 import Request from 'reqwest';
 
 import { createStore, combineReducers } from 'redux';
+import Proj from 'ol/proj';
 
 import * as mapSourceActions from './actions/mapSource';
 import * as mapActions from './actions/map';
@@ -524,8 +525,13 @@ class Application {
     /** Move the map to a center point and a resolution.
      *
      */
-    zoomTo(lon, lat, resolution) {
-        this.store.dispatch(mapActions.move([lon, lat], resolution));
+    zoomTo(lon, lat, zoom) {
+        // TODO: The destination projection should come
+        //       from the map state.
+        // convert the lon lat coordinates to map coordinates
+        const xy = Proj.transform([lon, lat], 'EPSG:4326', 'EPSG:3857');
+        // trigger a move.
+        this.store.dispatch(mapActions.move(xy, zoom));
     }
 
     /** Generic bridge to the application's store's dispatch function.

--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -968,7 +968,6 @@ class Map extends Component {
             // get the view of the map
             let view = this.map.getView();
             // create a "mapAction" and dispatch it.
-            // this.props.store.dispatch(mapActions.move(view.getCenter(), view.getResolution()));
             this.props.store.dispatch(mapActions.setView({
                 center: view.getCenter(),
                 resolution: view.getResolution(),
@@ -1262,6 +1261,10 @@ class Map extends Component {
 
                 this.map.getView().setCenter(view.center);
                 this.map.getView().setResolution(view.resolution);
+            }
+
+            if(map_view.getZoom() !== view.zoom) {
+                this.map.getView().setZoom(view.zoom);
             }
         }
 

--- a/tests/gm3/application.test.js
+++ b/tests/gm3/application.test.js
@@ -122,10 +122,10 @@ describe('application api calls', () => {
     });
 
     it('zooms to a location', () => {
-        app.zoomTo(1000, 1000, 200);
+        app.zoomTo(-93, 45, 11);
 
         const map_view = app.store.getState().map;
-        expect(map_view.center).toEqual([1000, 1000]);
-        expect(map_view.resolution).toBe(200);
+        expect(map_view.center).toEqual([-10352712.643774442, 5621521.486192066]);
+        expect(map_view.resolution).toBe(100);
     });
 });


### PR DESCRIPTION
This fixes an expectation bug more than anything else.

After meeting with some users, and looking at the other
Javascript/GIS APIs, conceptualizing a "zoom" level is easier
than necessarily specifying a resolution.

refs: #242 