### PR TITLE
Limit file upload dialog to supported types.

### DIFF
--- a/src/gm3/components/catalog/tools/upload.jsx
+++ b/src/gm3/components/catalog/tools/upload.jsx
@@ -125,7 +125,7 @@ class UploadModal extends Modal {
                     { this.props.helpText }
                 </p>
                 <p>
-                    <input ref='fileInput' type='file'/>
+                    <input ref='fileInput' type='file' accept='.geojson,.json,.kml'/>
                 </p>
             </div>
         );


### PR DESCRIPTION
*.geojson, *.json, *.kml

Tested: FF52 Linux. IE 11 and Chrome 61 Windows

Refs: #29