### PR TITLE
Updated KML filename sniffer for windows compat

### DIFF
--- a/src/gm3/components/catalog/tools/upload.jsx
+++ b/src/gm3/components/catalog/tools/upload.jsx
@@ -159,7 +159,7 @@ class UploadModal extends Modal {
                     // input_format is defaulted to null and only
                     //  set if the file format can be inferred.
                     let input_format = null;
-                    if(file.type.indexOf('kml') >= 0) {
+                    if(String(file.name).split('.').pop() === 'kml') {
                         // sweet, KML file.
                         input_format = new KMLFormat();
                     } else {

--- a/src/gm3/components/catalog/tools/upload.jsx
+++ b/src/gm3/components/catalog/tools/upload.jsx
@@ -159,7 +159,7 @@ class UploadModal extends Modal {
                     // input_format is defaulted to null and only
                     //  set if the file format can be inferred.
                     let input_format = null;
-                    if(String(file.name).split('.').pop() === 'kml') {
+                    if(String(file.name).toLowerCase().split('.').pop() === 'kml') {
                         // sweet, KML file.
                         input_format = new KMLFormat();
                     } else {


### PR DESCRIPTION
Windows was not checking the mime-type properly. File.type was
consistently set to ''. This uses the (inferior) filename test
in order to detect the type of parsers which should be used.

refs: #235 