### PR TITLE
Improvements to search

### DIFF
--- a/docs/howto/add-search-layer-picker.md
+++ b/docs/howto/add-search-layer-picker.md
@@ -1,0 +1,77 @@
+# How-to let the user choose a search layer
+
+Sometimes data is stored across multiple layers and writing
+multiple instances of the Search service is too laborious for
+both the administrator and the user. This is an example
+configuration that will allow searching two different layers,
+with two different field names, from the same text box.
+
+## Code
+
+This example refers to the `firestations-wfs` layer. This is used in other
+tutorials and the data is included in the gm3-demo-data repository.
+
+```xml
+<map-source name="firestations-wfs" type="mapserver-wfs">
+    <file>./demo/firestations/firestations.map</file>
+    <param name="typename" value="ms:fire_stations" />
+    <layer name="fire_stations" selectable="true" title="Firestations">
+        <template name="select"><![CDATA[
+        <div class="result-item">
+            <div class="result-title">
+            Firestation
+            </div>
+            <b>Station City:</b> {{ properties.Dak_GIS__4 }}<br>
+            <b>Station Number:</b> {{ properties.Dak_GIS__5 }}<br>
+        <div>
+        ]]></template>
+        <template name="search" alias="select" />
+    </layer>
+</map-source>
+```
+
+### In app.js
+
+```javascript
+    app.registerService('super-search', SearchService, {
+        fields: [
+            {
+                type: 'select',
+                name: 'layer',
+                options: [
+                    {value: 'vector-parcels/parcels', label: 'Parcel Owners'},
+                    {value: 'firestations-wfs/fire_stations', label: 'Firestations'}
+                ]
+            }, {
+                type: 'text',
+                name: 'search-value',
+            }
+        ],
+        prepareFields: function(fields) {
+            var values = getFieldValues(fields);
+            var field_name = {
+                'vector-parcels/parcels' : 'OWNER_NAME',
+                'firestations-wfs/fire_stations' : 'Dak_GIS__4'
+            };
+            return [{
+                comparitor: 'ilike',
+                name: field_name[values['layer']],
+                value: values['search-value']
+            }];
+        },
+        getSearchLayers: function(searchLayers, fields) {
+            console.log(getFieldValues(fields));
+            return [getFieldValues(fields)['layer']];
+        }
+    });
+```
+
+### In the catalog
+
+```xml
+    <toolbar>
+        ...
+            <tool name="super-search" title="Super Search" type="service"/>
+        ...
+    </toolbar>
+```

--- a/examples/desktop/app.css
+++ b/examples/desktop/app.css
@@ -156,3 +156,8 @@ body {
 .feature-class.pipelines {
     background-color: #4894ff;
 }
+
+.search-address {
+    font-size: .85em;
+    padding-left: 1em;
+}

--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -63,7 +63,15 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     });
 
     app.registerService('identify', IdentifyService);
-    app.registerService('search', SearchService);
+    app.registerService('search', SearchService, {
+        fields: [
+            {type: 'text', label: 'Owner Name', name: 'OWNER_NAME'},
+            {type: 'text', label: 'Street/Address', name: 'OWN_ADD_L1'},
+            {type: 'text', label: 'City/State/ZIP', name: 'OWN_ADD_L3'}
+        ],
+        searchLayers: ['vector-parcels/parcels']
+    });
+
     app.registerService('search-firestations', SearchService, {
         searchLayers: ['firestations/fire_stations'],
         fields: [

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -83,6 +83,10 @@
                             </a>
                         </div>
                     </div>
+                    <div class="search-address">
+                        {{ properties.OWN_ADD_L1 }}<br/>
+                        {{ properties.OWN_ADD_L3 }}<br/>
+                    </div>
                 </div>
             ]]></template>
 
@@ -503,7 +507,7 @@
         <tool name="select" title="Select Features" type="service"/>
 
         <drawer name="searches" title="Search">
-            <tool name="search" title="Search by Owner" type="service"/>
+            <tool name="search" title="Search Parcels" type="service"/>
             <tool name="geocode" title="Search by Address" type="service"/>
         </drawer>
 

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -245,6 +245,7 @@ class Application {
             //  wants to do something after the mapbook has loaded.
             return Request({
                 url: options.url,
+                type: 'xml',
                 success: (response) => {
                     this.populateMapbook(response);
                 }

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -57,7 +57,7 @@ function SearchService(Application, options) {
     /** Allow the user to programmatically change which
      *  layers are searched.
      */
-    this.getSearchLayers = options.getSearchLayers ? option.getSearchLayers : function(searchLayers, fields) {
+    this.getSearchLayers = options.getSearchLayers ? options.getSearchLayers : function(searchLayers, fields) {
         return searchLayers;
     };
 

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -49,25 +49,33 @@ function SearchService(Application, options) {
 
     /** User input fields */
     this.fields = options.fields ? options.fields : [
-        {type: 'text', label: 'Owner Name', name: 'OWNER_NAME'}
     ];
 
     /** Define the layer(s) to be searched. */
-    this.searchLayers = options.searchLayers ? options.searchLayers : [
-        'vector-parcels/parcels'
-    ];
+    this.searchLayers = options.searchLayers ? options.searchLayers : [];
+
+    /** Allow the user to programmatically change which
+     *  layers are searched.
+     */
+    this.getSearchLayers = options.getSearchLayers ? option.getSearchLayers : function(searchLayers, fields) {
+        return searchLayers;
+    };
 
     /** Field transfomation function. */
     this.prepareFields = options.prepareFields ? options.prepareFields : function(fields) {
         // reformat the fields for the query engine,
         //  "*stuff*" will do a case-ignored "contains" query.
-        return [
-            {
-                comparitor: 'ilike',
-                name: fields[0].name,
-                value: '*' + fields[0].value + '*'
+        var query = [];
+        for(var i = 0, ii = fields.length; i < ii; i++) {
+            if(fields[i].value !== '' && fields[i].value !== undefined) {
+                query.push({
+                    comparitor: 'ilike',
+                    name: fields[i].name,
+                    value: '*' + fields[i].value + '*'
+                });
             }
-        ];
+        }
+        return query;
     };
 
     /** Define the results layer */
@@ -88,9 +96,14 @@ function SearchService(Application, options) {
         //  it would be necessary to put that code here and then manually tell
         //  the application when the query has finished, at which point resultsAsHtml()
         //  would be called by the service tab.
-        Application.dispatchQuery(this.name, selection, this.prepareFields(fields), this.searchLayers, this.template);
+        Application.dispatchQuery(
+            this.name,
+            selection,
+            this.prepareFields(fields),
+            this.getSearchLayers(this.searchLayers, fields),
+            this.template
+        );
     }
-
 
     /** resultsAsHtml is the function used to populate the Service Tab
      *                after the service has finished querying.


### PR DESCRIPTION
1. Search no longer pre-defines parcels.
   This change was made to add clarity to show what search was
   already doing internally.
2. Added the ability to override the searchLayers with a function.
   getSearchLayers is passed this.searchLayers and fields.  This will
   allow users to change which layres are searched based on inputs.
3. Updates to show off the new multi-field search capability in the desktop
   demo.