### PR TITLE
Added uniqueness check for grid's list filter

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -110,6 +110,14 @@
                     "sortAs" : "string"
                 },
                 {
+                    "title" : "City",
+                    "property" : "CITY",
+                    "sortAs" : "string",
+                    "filter" : {
+                        "type" : "list"
+                    }
+                },
+                {
                     "title" : "Est. Value",
                     "property" : "EMV_TOTAL",
                     "sortAs" : "number",
@@ -133,6 +141,7 @@
                   {{ properties.PIN }}
                 </td>
                 <td>{{ properties.OWNER_NAME }}</td>
+                <td>{{ properties.CITY }}</td>
                 <td style="text-align: right">${{ properties.EMV_TOTAL | number | localize }}</td>
             </tr>
             ]]></template>

--- a/src/gm3/components/grid.jsx
+++ b/src/gm3/components/grid.jsx
@@ -162,11 +162,15 @@ class ListFilterModal extends FilterModal {
             const prop = this.props.column.property;
             // when the values are not specified they need
             // to be pulled from the results.
+            const uniq_check = {};
             for(const result of this.props.results) {
                 const v = result.properties[prop];
-                this.filter_values.push({
-                    value: v, label: v
-                });
+                if(uniq_check[v] !== true) {
+                    this.filter_values.push({
+                        value: v, label: v
+                    });
+                }
+                uniq_check[v] = true;
             }
         }
 


### PR DESCRIPTION
1. Previous version of list assumed the pick list was
   a set of unique values which wasn't strictly true.
2. Created a demo by using city names with the parcel grid.

refs: #255 