### PR TITLE
Added a control to allow clearing selections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ node_js:
 before_script:
     - sudo apt-get -qq update
     - sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
-    - npm install canvas
+    - npm install canvas@1.6.7
     - grunt lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@
 dist: trusty
 language: node_js
 node_js:
-    - "node"
+    - "8"
 
 # setup some solid deps.
 

--- a/src/gm3/components/serviceManager.jsx
+++ b/src/gm3/components/serviceManager.jsx
@@ -36,7 +36,7 @@ import * as uuid from 'uuid';
 
 import * as mapActions from '../actions/map';
 
-import { getLayerFromPath } from '../actions/mapSource';
+import { clearFeatures, getLayerFromPath } from '../actions/mapSource';
 
 import { setUiHint } from '../actions/ui';
 
@@ -413,6 +413,11 @@ class ServiceManager extends Component {
         }
     }
 
+    clearSelectionFeatures() {
+        this.props.dispatch(mapActions.clearSelectionFeatures());
+        this.props.dispatch(clearFeatures('selection'));
+    }
+
     componentWillUpdate(nextProps, nextState) {
         // anytime this updates, the user should really be seeing the service
         //  tab.
@@ -588,10 +593,29 @@ class ServiceManager extends Component {
                     </div>
                 );
             } else {
+                // when there are no queries but a selection is left
+                //  allow the user to remove the selection
+                let enable_clear = false;
+                if(this.props.selectionSrc
+                  && this.props.selectionSrc.features
+                  && this.props.selectionSrc.features.length > 0) {
+                    enable_clear = true;
+                }
+
                 return (
                     <div className="service-manager">
                         <div className="info-box">
                             Nothing available to view. Please click a service to start in the toolbar.
+                        </div>
+
+                        <div className="clear-controls">
+                            <button
+                                disabled={ !enable_clear }
+                                className="clear-button"
+                                onClick={ () => { this.clearSelectionFeatures(); } }
+                            >
+                                <i className="clear icon"></i> Clear previous selections
+                            </button>
                         </div>
                     </div>
                 );
@@ -605,7 +629,8 @@ class ServiceManager extends Component {
 const mapToProps = function(store) {
     return {
         queries: store.query,
-        map: store.map
+        map: store.map,
+        selectionSrc: store.mapSources.selection
     }
 }
 export default connect(mapToProps)(ServiceManager);

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -114,4 +114,8 @@
             border: solid 1px red;
         }
     }
+
+    .clear-controls {
+        text-align: center;
+    }
 }


### PR DESCRIPTION
After all queries have been removed from the selection tab,
the selection polygon would continue to be displayed.

This new functionality fixes that issue by adding a button
allowing the user to clear the polygon.  This was done as a bit
of a compromise. Ostensibly, a complex selection area may need to be
re-used even if the user wants to clear teh current results.  Automatically
removing the selection area would've made that impossible.

Steps to use:
1. run a query with a drawn selection feature.
2. click "delete" / trash-can icon on the results.
3. See that there is now a polygon on display.
4. click the 'clear' button in the service manager tab.

refs: #257 