### PR TITLE
Tweak WFS settings to use "%"

### DIFF
--- a/src/gm3/components/map.jsx
+++ b/src/gm3/components/map.jsx
@@ -299,7 +299,7 @@ class Map extends Component {
         let filter_mapping = {
             'like': ol_filters.like,
             'ilike': function(name, value) {
-                return ol_filters.like(name, value, '*', '.', '!', false);
+                return ol_filters.like(name, value, '%', '_', '\\', false);
             },
             'eq': ol_filters.equalTo,
             'ge': ol_filters.greaterThanOrEqualTo,

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -71,7 +71,7 @@ function SearchService(Application, options) {
                 query.push({
                     comparitor: 'ilike',
                     name: fields[i].name,
-                    value: '*' + fields[i].value + '*'
+                    value: '%' + fields[i].value + '%'
                 });
             }
         }


### PR DESCRIPTION
The settings of using "*" and "\_" didn't appear to work
with SQL sources.  This version uses the "%" and "_" conventions
that are more similar to SQL.

refs: #279 