### PR TITLE
Rename and Repairs for OSM Geocode

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -470,7 +470,7 @@
 
         <drawer name="searches" title="Search">
             <tool name="search" title="Search Parcels" type="service"/>
-            <tool name="geocode" title="Search by Address" type="service"/>
+            <tool name="geocode" title="Geocode an Address" type="service"/>
         </drawer>
 
         <tool name="findme" title="Find Me" type="action"/>

--- a/src/gm3/application.jsx
+++ b/src/gm3/application.jsx
@@ -459,6 +459,11 @@ class Application {
                     }
 
                 }
+            } else if(template) {
+                // assume the template is template contents.
+                for(let feature of query.results[path]) {
+                    html_contents += Mark.up(template, feature, util.FORMAT_OPTIONS);
+                }
             }
         }
 

--- a/src/services/geocode-osm.js
+++ b/src/services/geocode-osm.js
@@ -49,7 +49,7 @@ function OSMGeocoder(Application, options) {
      *  other than the demo application.
      */
     this.template = '<div class="search-result">' +
-                    '<a onClick="app.zoomToExtent([{{ properties.boundingbox.2 }}, {{ properties.boundingbox.0 }}, {{ properties.boundingbox.3 }}, {{ properties.boundingbox.1 }}], \'EPSG:4326\')" class="zoomto-link">' +
+                    '<a onClick="app.zoomTo({{ properties.lon }}, {{ properties.lat }}, 18)" class="zoomto-link">' +
                         '<i class="fa fa-search"></i>' +
                         '{{ properties.display_name }}' +
                     '</a>' +


### PR DESCRIPTION
1. Renamed the address geocoder to increase clarity.
2. Fixed the issue with fixed templates not rendering.
3. Switched the templates to zoomTo instead of zoomToExtent,
   making the view a bit more reasonable.

refs: #277 