### PR TITLE
Comment out site.css.

### DIFF
--- a/examples/desktop/debug.html
+++ b/examples/desktop/debug.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" href="../dist/css/geomoose.css">
     -->
     <link rel="stylesheet" type="text/css" href="app.css"/>
-    <link rel="stylesheet" type="text/css" href="site.css"/>
+    <!--link rel="stylesheet" type="text/css" href="site.css"/-->
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <!--

--- a/examples/desktop/index.html
+++ b/examples/desktop/index.html
@@ -6,7 +6,7 @@
     <title>GeoMoose 3 Test Instance</title>
     <link rel="stylesheet" type="text/css" href="../geomoose/dist/css/geomoose.css">
     <link rel="stylesheet" type="text/css" href="app.css"/>
-    <link rel="stylesheet" type="text/css" href="site.css"/>
+    <!--link rel="stylesheet" type="text/css" href="site.css"/-->
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <!--


### PR DESCRIPTION
site.css is referenced in the docs as a suggested place for a site
admin to place their site-specific CSS rules.  However, as it is
not a shipped file, it is causing 404 errors in the desktop
example that while harmless are nonetheless concerning for users.

ref: #276