### PR TITLE
Added a tab check to the less linter.

### DIFF
--- a/src/tasks/grunt-less-linter.js
+++ b/src/tasks/grunt-less-linter.js
@@ -49,6 +49,8 @@ module.exports = function(grunt) {
                 in_value = false;
             } else if(chr === '#' && !in_value) {
                 throw grunt.util.error('ID selector found in [' + filename + ':' + line_no + ']');
+            } else if(chr === '\t') {
+                throw grunt.util.error('No tabs allowed! Tab found in [' + filename + ':' + line_no + ']');
             } else if(chr === '\n') {
                 line_no++;
             }


### PR DESCRIPTION
Looks for \t's throws errors when they are there.

refs: #290 