### PR TITLE
Restore X,Y label to coordinate-display.

### DIFF
--- a/src/gm3/components/coordinate-display.js
+++ b/src/gm3/components/coordinate-display.js
@@ -181,7 +181,7 @@ export default class CoordinateDisplay extends React.Component {
             case 'xy':
                 display = (
                     <span className='coordinates map-xy' key='xy'>
-                        { formatCoordinates(projection, this.props.coords, 1) }
+                        <label>{projection.label}</label> { formatCoordinates(projection, this.props.coords, 1) }
                     </span>
                 );
                 break;


### PR DESCRIPTION
Looks like this was lost in 6ef3b42c.

ref: #337