### PR TITLE
search field values validation

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -69,7 +69,30 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
             {type: 'text', label: 'Street/Address', name: 'OWN_ADD_L1'},
             {type: 'text', label: 'City/State/ZIP', name: 'OWN_ADD_L3'}
         ],
-        searchLayers: ['vector-parcels/parcels']
+        searchLayers: ['vector-parcels/parcels'],
+        validateFieldValues: function (fields) {
+            let nonEmpty = 0;
+            const validateFieldValuesResult = {
+                valid: true,
+                message: null
+            };
+
+            if (fields['OWNER_NAME'] !== undefined && fields['OWNER_NAME'] !== '') {
+                    nonEmpty++;
+            }
+            if (fields['OWN_ADD_L1'] !== undefined && fields['OWN_ADD_L1'] !== '') {
+                nonEmpty++;
+            }
+            if (fields['OWN_ADD_L3'] !== undefined && fields['OWN_ADD_L3'] !== '') {
+                nonEmpty++;
+            }
+
+            if (nonEmpty === 0) {
+                validateFieldValuesResult.valid = false;
+                validateFieldValuesResult.message = 'Please complete at least one field.'
+            }
+            return validateFieldValuesResult;
+        }
     });
 
     app.registerService('search-firestations', SearchService, {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ],
     "setupFiles": [
       "./tests/setup.js"
-    ]
+    ],
+    "testURL": "http://localhost"
   },
   "author": "Dan 'Ducky' Little",
   "license": "MIT",

--- a/src/gm3/components/serviceForm.js
+++ b/src/gm3/components/serviceForm.js
@@ -67,6 +67,8 @@ export default class ServiceForm extends React.Component {
 
         this.state = {
             values,
+            validateFieldValuesResultMessage: null,
+            lastService: null,
         };
     }
 
@@ -82,6 +84,14 @@ export default class ServiceForm extends React.Component {
             this.props.onSubmit(this.state.values);
         } else if(code === 27) {
             this.props.onCancel();
+        }
+    }
+
+    UNSAFE_componentWillUpdate(nextProps, nextState) {
+        if(this.state.lastService !== nextProps.serviceDef
+            && nextProps.serviceDef !== null) {
+            // 'rotate' the current service to the next services.
+            this.setState({lastService: nextProps.serviceDef, validateFieldValuesResultMessage: null});
         }
     }
 
@@ -125,9 +135,34 @@ export default class ServiceForm extends React.Component {
                         return renderServiceField(field, this.state.values[field.name], onChange);
                     })
                 }
+                {
+                    !this.state.validateFieldValuesResultMessage ? false : (
+                        <div className="query-error">
+                            <div className="error-header">Error</div>
+                            <div className="error-contents">
+                                { this.state.validateFieldValuesResultMessage }
+                            </div>
+                        </div>
+                    )
+                }
                 <div className='tab-controls'>
                     <button className='close-button' onClick={() => { this.props.onCancel(); }}><i className='close-icon'></i> Close</button>
-                    <button className='go-button' onClick={() => { this.props.onSubmit(this.state.values); }}><i className='go-icon'></i> Go</button>
+                    <button className='go-button' onClick={() =>
+                    {
+                        // validate field values
+                        let validateFieldValuesResultValid = true;
+                        let validateFieldValuesResultMessage = null;
+                        if (service_def.validateFieldValues) {
+                            const validateFieldValuesResult = service_def.validateFieldValues(this.state.values);
+                            validateFieldValuesResultValid = validateFieldValuesResult.valid;
+                            validateFieldValuesResultMessage = validateFieldValuesResult.message;
+                        }
+                        if (validateFieldValuesResultValid) {
+                            this.props.onSubmit(this.state.values);
+                        }
+                        // update state validation message
+                        this.setState( {validateFieldValuesResultMessage} );
+                    }}><i className='go-icon'></i> Go</button>
                 </div>
             </div>
         );

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -113,11 +113,6 @@
             padding: 4px;
             border: solid 1px red;
         }
-
-        .error-text-message {
-            padding: 4px;
-            color: red;
-        }
     }
 
     .clear-controls {

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -113,6 +113,11 @@
             padding: 4px;
             border: solid 1px red;
         }
+
+        .error-text-message {
+            padding: 4px;
+            color: red;
+        }
     }
 
     .clear-controls {

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -61,6 +61,14 @@ function SearchService(Application, options) {
         return searchLayers;
     };
 
+    /** Allow the user to programmatically validate form field values. */
+    this.validateFieldValues = options.validateFieldValues ? options.validateFieldValues : function (fields) {
+        return {
+            valid: true,
+            message: null
+        };
+    };
+
     /** Field transfomation function. */
     this.prepareFields = options.prepareFields ? options.prepareFields : function(fields) {
         // reformat the fields for the query engine,


### PR DESCRIPTION
This pull request allows the user to add validation to the search fields. It is achieve using the new `validateFieldValues` method of the search service. This method takes as an argument the field values (object `{fieldName: value}`) and returns a boolean value that indicate if the input is valid and a correspondent error message (object `{valid: boolean, message: string}`).

The main changes are in `serviceForm.js`:
- two new state property were added `validateFieldValuesResultMessage` and `lastService`,
- a div message for the error was added, that shows in case `validateFieldValuesResultMessage` is not null
- an invocation to the service `validateFieldValues` is made, if exist, on the click event of the go button
- the component `UNSAFE_componentWillUpdate` method was added to udate the state of the new properties if it is a new service