### PR TITLE
Adding Min/Max-resolution support to catalog + map

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -32,9 +32,9 @@
         </layer>
     </map-source>
 
-    <map-source name="places" type="geojson" title="Cities and Villages">
+    <map-source name="places" type="geojson" title="Cities and Villages" minresolution="1000" maxresolution="5000">
         <url>./places.geojson</url>
-        <layer name="default" title="Cities and Villages">
+        <layer name="default">
             <style><![CDATA[
             {
                 "line-color" : "#9e8647",

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -32,7 +32,7 @@
         </layer>
     </map-source>
 
-    <map-source name="places" type="geojson" title="Cities and Villages" minresolution="1000" maxresolution="5000">
+    <map-source name="places" type="geojson" title="Cities and Villages" minresolution="100" maxresolution="5000">
         <url>./places.geojson</url>
         <layer name="default">
             <style><![CDATA[

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "plugins": []
   },
   "jest": {
-    "testURL": "http://geo.moose/",
+    "testURL": "http://localhost",
     "transformIgnorePatterns": [
       "node_modules/(?!ol|mapbox|jsts)"
     ],
@@ -34,8 +34,7 @@
     ],
     "setupFiles": [
       "./tests/setup.js"
-    ],
-    "testURL": "http://localhost"
+    ]
   },
   "author": "Dan 'Ducky' Little",
   "license": "MIT",

--- a/src/gm3/actions/catalog.js
+++ b/src/gm3/actions/catalog.js
@@ -104,10 +104,13 @@ function parseLayer(store, layerXml) {
         }
     }
 
-    // parse a refresh time if it exists
-    if(layerXml.getAttribute('refresh')) {
-        new_layer.refresh = parseFloat(layerXml.getAttribute('refresh'));
-    }
+    // parse the optional float attributes
+    ['refresh', 'minresolution', 'maxresolution'].forEach((attr) => {
+        const value = layerXml.getAttribute(attr);
+        if(value) {
+            new_layer[attr] = parseFloat(value);
+        }
+    });
 
     // collect the src states
     let src_favorite = false;
@@ -116,6 +119,7 @@ function parseLayer(store, layerXml) {
     const src_str = layerXml.getAttribute('src');
     if(src_str) {
         const map_sources = store.getState().mapSources;
+        const inhert_attrs = ['minresolution', 'maxresolution', 'label'];
 
         // migrated to ";" as the split key because the old ":"
         //  was problematic for WFS layers which specified a schema.
@@ -137,12 +141,12 @@ function parseLayer(store, layerXml) {
             //  are false, then turn all of them off.
             src_favorite = src_favorite || mapSources.isFavoriteLayer(map_sources, s);
 
-            // check to see if a 'default' name is needed
-            // for the catalog entry.
-            if(!new_layer.label && map_sources[s.mapSourceName].label) {
-                new_layer.label = map_sources[s.mapSourceName].label;
-            }
-
+            inhert_attrs.forEach((attr) => {
+                const value = map_sources[s.mapSourceName][attr];
+                if (!new_layer[attr] && value) {
+                    new_layer[attr] = value;
+                }
+            });
         }
     }
 

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -198,16 +198,13 @@ export function addFromXml(xml, config) {
         Object.assign(map_source, mapServerToWFS(xml, config));
     }
 
-    // check to see if there is a refresh interval.
-    if(xml.getAttribute('refresh')) {
-        // parse the refresh number
-        const refresh_seconds = parseFloat(xml.getAttribute('refresh'));
-        // this will be truthy when a number has been returned,
-        //  NaN or Infinitity should return as falsy.
-        if(refresh_seconds) {
-            map_source.refresh = refresh_seconds;
+    // parse the optional float attributes
+    ['refresh', 'minresolution', 'maxresolution'].forEach((attr) => {
+        const value = xml.getAttribute(attr);
+        if(value) {
+            map_source[attr] = parseFloat(value);
         }
-    }
+    });
 
     // catalog the transforms for the layer
     const transforms = xml.getElementsByTagName('transform');
@@ -281,8 +278,6 @@ export function addFromXml(xml, config) {
             }
 
             layer.templates[template_name] = template_def;
-
-
         }
 
         // check to see if there are any style definitions

--- a/src/gm3/components/catalog/layer.js
+++ b/src/gm3/components/catalog/layer.js
@@ -23,6 +23,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import ClearTool from './tools/clear';
 import DownTool from './tools/down';
@@ -41,7 +42,7 @@ import Legend from './legend';
 import LayerCheckbox from './layer-checkbox';
 import LayerFavorite from './layer-favorite';
 
-export default class CatalogLayer extends React.Component {
+export class CatalogLayer extends React.Component {
     /* Convert the tool definitions to components.
      */
     getTools(layer, enabledTools) {
@@ -105,12 +106,13 @@ export default class CatalogLayer extends React.Component {
             layer_classes.push('on');
         }
 
-        // TODO: Check layer for minscale/maxscale against
-        //       the mapView.
-        // if(isOutOfScale(layer)) {
-        //  layer_classes.push('out-of-scale');
-        // }
-
+        if((layer.minresolution || layer.maxresolution) && this.props.resolution) {
+            const min_z = layer.minresolution !== undefined ? layer.minresolution : -1;
+            const max_z = layer.maxresolution !== undefined ? layer.maxresolution : 1000;
+            if (this.props.resolution < min_z || this.props.resolution > max_z) {
+                layer_classes.push('out-of-resolution');
+            }
+        }
 
         const tools = this.getToolsForLayer(layer);
 
@@ -153,3 +155,11 @@ CatalogLayer.propTypes = {
 CatalogLayer.defaultProps = {
     forceTools: [],
 };
+
+function mapState(state) {
+    return {
+        resolution: state.map ? state.map.resolution : -1,
+    };
+}
+
+export default connect(mapState)(CatalogLayer);

--- a/src/gm3/components/layers/ags.js
+++ b/src/gm3/components/layers/ags.js
@@ -52,7 +52,9 @@ function defineSource(mapSource) {
  */
 export function createLayer(mapSource) {
     return new TileLayer({
-        source: new ArcRestSource(defineSource(mapSource))
+        source: new ArcRestSource(defineSource(mapSource)),
+        minResolution: mapSource.minresolution,
+        maxResolution: mapSource.maxresolution,
     });
 }
 

--- a/src/gm3/components/layers/bing.js
+++ b/src/gm3/components/layers/bing.js
@@ -75,7 +75,9 @@ function defineSource(mapSource) {
  */
 export function createLayer(mapSource) {
     return new TileLayer({
-        source: new BingSource(defineSource(mapSource))
+        source: new BingSource(defineSource(mapSource)),
+        minResolution: mapSource.minresolution,
+        maxResolution: mapSource.maxresolution,
     });
 }
 

--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -249,6 +249,8 @@ export function createLayer(mapSource) {
 
     const opts = {
         source,
+        minResolution: mapSource.minresolution,
+        maxResolution: mapSource.maxresolution,
     };
     const vector_layer = new VectorLayer(opts);
     applyStyle(vector_layer, mapSource);

--- a/src/gm3/components/layers/wms.js
+++ b/src/gm3/components/layers/wms.js
@@ -50,8 +50,10 @@ function defineSource(mapSource) {
             'VERSION': '1.1.1',
             'LAYERS': layers.join(',')
         }, mapSource.params),
-        serverType: mapSource.serverType
-    }
+        serverType: mapSource.serverType,
+        minResolution: mapSource.minresolution,
+        maxResolution: mapSource.maxresolution,
+    };
 }
 
 

--- a/src/gm3/components/layers/xyz.js
+++ b/src/gm3/components/layers/xyz.js
@@ -52,7 +52,9 @@ function defineSource(mapSource) {
  */
 export function createLayer(mapSource) {
     return new TileLayer({
-        source: new XYZSource(defineSource(mapSource))
+        source: new XYZSource(defineSource(mapSource)),
+        minResolution: mapSource.minresolution,
+        maxResolution: mapSource.maxresolution,
     });
 }
 

--- a/src/less/catalog.less
+++ b/src/less/catalog.less
@@ -104,6 +104,11 @@
         margin-right: .25em;
         margin-left: .25em;
     }
+
+    &.out-of-resolution {
+        color: #aaa;
+        font-style: italic;
+    }
 }
 
 .catalog {


### PR DESCRIPTION
1. Added suppot for `minresolution` and `maxresolution`
   to map-sources and catalogs.
2. Added default CSS to style the layers.
3. Added example to mapbook.