### PR TITLE
Allow labeling drawtools, reordering fields to the top

### DIFF
--- a/src/gm3/components/drawTool.js
+++ b/src/gm3/components/drawTool.js
@@ -90,7 +90,7 @@ class DrawTool extends React.Component {
 
         let tool_label = gtype;
         if(gtype === 'Select') {
-            tool_label = 'Select from: ';
+            tool_label = 'Feature from: ';
             select_options = (
                 <select value={ this.state.selectLayer } onChange={ this.changeSelectLayer }>
                     { this.getSelectOptions() }

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -65,7 +65,7 @@ import olCollection from 'ol/Collection';
 import olSelectInteraction from 'ol/interaction/Select';
 import olDrawInteraction from 'ol/interaction/Draw';
 import olModifyInteraction from 'ol/interaction/Modify';
-import olEventConditions from 'ol/events/condition';
+import * as olEventConditions from 'ol/events/condition';
 
 import olZoomControl from 'ol/control/Zoom';
 import olRotateControl from 'ol/control/Rotate';

--- a/src/gm3/components/serviceForm.js
+++ b/src/gm3/components/serviceForm.js
@@ -101,6 +101,9 @@ export default class ServiceForm extends React.Component {
         const show_buffer = service_def.bufferAvailable;
 
         const draw_tools = [];
+        if (service_def.drawToolsLabel) {
+            draw_tools.push((<label key='label'>{ service_def.drawToolsLabel }</label>));
+        }
         for(const gtype of ['Point', 'MultiPoint', 'LineString', 'Polygon', 'Select', 'Modify']) {
             const dt_key = 'draw_tool_' + gtype;
             if(service_def.tools[gtype]) {
@@ -114,6 +117,21 @@ export default class ServiceForm extends React.Component {
             this.setState({values});
         };
 
+        const buffer_input = !show_buffer ? false : (
+            <BufferInput key='buffer-input'/>
+        );
+
+        const fields = this.props.serviceDef.fields.map((field) => {
+            return renderServiceField(field, this.state.values[field.name], onChange);
+        });
+
+        let inputs = [];
+        if (service_def.fieldsFirst === true) {
+            inputs = [fields, draw_tools, buffer_input];
+        } else {
+            inputs = [draw_tools, buffer_input, fields];
+        }
+
         return (
             <div className='service-form'
                 onKeyUp={(evt) => {
@@ -122,19 +140,7 @@ export default class ServiceForm extends React.Component {
             >
 
                 <h3>{service_def.title}</h3>
-                {
-                    draw_tools
-                }
-                {
-                    !show_buffer ? false : (
-                        <BufferInput />
-                    )
-                }
-                {
-                    this.props.serviceDef.fields.map((field) => {
-                        return renderServiceField(field, this.state.values[field.name], onChange);
-                    })
-                }
+                { inputs }
                 {
                     !this.state.validateFieldValuesResultMessage ? false : (
                         <div className="query-error">

--- a/src/gm3/components/serviceInputs/buffer.js
+++ b/src/gm3/components/serviceInputs/buffer.js
@@ -15,7 +15,7 @@ export class BufferInput extends React.Component {
         // inputs require a 'field' to render their label and
         // set their value.  This mocks that up.
         const mock_field = {
-            label: 'Buffer',
+            label: 'With buffer',
             value: this.props.distance,
             default: this.props.distance,
         };

--- a/src/gm3/components/serviceInputs/layersList.js
+++ b/src/gm3/components/serviceInputs/layersList.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Dan "Ducky" Little
+ * Copyright (c) 2016-2019 Dan "Ducky" Little
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,11 @@ import SelectInput from './select';
 
 import { getQueryableLayers, getLayerByPath } from '../../actions/mapSource';
 
+// special list of layers that should never float to the top.
+const TO_THE_BOTTOM = [
+    'sketch/default',
+];
+
 export class LayersListInput extends SelectInput {
     getOptions() {
         const options = [];
@@ -38,7 +43,15 @@ export class LayersListInput extends SelectInput {
                 label: layer.label,
             });
         }
-        return options;
+
+        return options.sort((a, b) => {
+            if (TO_THE_BOTTOM.indexOf(a.value) >= 0) {
+                return 1;
+            } else if (TO_THE_BOTTOM.indexOf(b.value) >= 0) {
+                return -1;
+            }
+            return a < b ? -1 : 1;
+        });
     }
 }
 

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -24,7 +24,7 @@
 
 .radio-option,.draw-tool {
     cursor: pointer;
-    padding-left: 15px;
+    padding-left: 5px;
 
     .radio-icon {
         .fa;
@@ -82,7 +82,8 @@
     }
 
     label {
-            font-weight: bold;
+        font-weight: bold;
+        margin-bottom: 1px;
     }
 
     .service-input {
@@ -90,6 +91,12 @@
             display: block;
             margin-top: 7px;
         }
+
+        select, input {
+            margin-left: 5px;
+        }
+
+        margin-bottom: 3px;
     }
 
     input[type='text'] {

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -78,7 +78,7 @@ function SelectService(Application, options) {
     this.fields = options.fields || [{
         type: 'layers-list',
         name: 'layer',
-        label: 'Query Layer',
+        label: 'Select from',
         default: options.defaultLayer,
         filter: {
             // ensure that the layer is visible to prevent confusion.
@@ -87,6 +87,12 @@ function SelectService(Application, options) {
             withTemplate: ['select', 'select-header']
         }
     }];
+
+    /** When true, put the query fields above any drawing tools. */
+    this.fieldsFirst = true;
+
+    /** When defined, label the draw tools */
+    this.drawToolsLabel = options.drawToolsLabel ? options.drawToolsLabel : 'Using';
 
     /** Alow shapes to be buffered. */
     this.bufferAvailable = true;


### PR DESCRIPTION

* Allow fields to go to the top of the list.
* Allow the draw tools to be labeled.
* Cleanup of Select service definition to use the fields and draw tools label.

refs: #302 