### PR TITLE
Prevent zoom-to-results from going too far

### DIFF
--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -64,7 +64,7 @@ function normalizeSelection(selectionFeatures) {
 /** Get the extent of a query's results.
  *  All features must have a boundedBy property.
  */
-function getExtentForQuery(results) {
+function getExtentForQuery(results, minSize = 150) {
     let extent = null;
 
     for(const path in results) {
@@ -82,6 +82,18 @@ function getExtentForQuery(results) {
             }
         }
     }
+
+    if (extent[3] - extent[1] < minSize || extent[2] - extent[0] < minSize) {
+        const mid_x = (extent[0] + extent[2]) / 2;
+        const mid_y = (extent[1] + extent[3]) / 2;
+        extent = [
+            mid_x - minSize,
+            mid_y - minSize,
+            mid_x + minSize,
+            mid_y + minSize,
+        ];
+    }
+
     return extent;
 }
 


### PR DESCRIPTION
This can be a praticular problem when returning a single
point (as in from a search) and zooming to the results will
take the user to a view which is not useful.  Adding a minimum
bounding box size prevents that from happening.