### PR TITLE
Fixing buffer and scale distances

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -31,7 +31,13 @@
 
 var app = new gm3.Application({
     mapserver_url: CONFIG.mapserver_url,
-    mapfile_root: CONFIG.mapfile_root
+    mapfile_root: CONFIG.mapfile_root,
+    map: {
+        scaleLine: {
+            enabled: true,
+            units: 'imperial'
+        }
+    }
 });
 
 app.uiUpdate = function(ui) {

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -101,26 +101,6 @@
        </layer>
     </map-source>
 
-    <map-source name="scalebar_miles" type="mapserver" title="Scalebar Miles">
-        <file>./demo/scalebars/scalebar_miles.map</file>
-        <layer name="scalebar_mi"/>
-        <param name="FORMAT" value="image/png"/>
-    </map-source>
-
-
-    <map-source name="scalebar_feet" type="mapserver" title="Scalebar Feet">
-        <file>./demo/scalebars/scalebar_feet.map</file>
-        <layer name="scalebar_feet"/>
-        <param name="FORMAT" value="image/png"/>
-    </map-source>
-
-
-    <map-source name="scalebar_kilometers" type="mapserver" title="Scalebar Kilometers">
-        <file>./demo/scalebars/scalebar_kilometers.map</file>
-        <layer name="scalebar_km"/>
-        <param name="FORMAT" value="image/png"/>
-    </map-source>
-
     <map-source name="pipelines" type="mapserver" title="Pipelines">
         <file>./demo/pipelines/pipelines.map</file>
         <layer name="pipelines" status="off">
@@ -424,12 +404,6 @@
             </group>
             <layer src="pipelines/pipelines"></layer>
             <layer title="Weather Radar" src="iastate/nexrad-n0r" />
-        </group>
-
-        <group title="Scalebars" expand="false">
-            <layer src="scalebar_miles/scalebar_mi" legend="false" show-legend="false" fade="false" unfade="false"/>
-            <layer src="scalebar_feet/scalebar_feet" legend="false" show-legend="false" fade="false" unfade="false"/>
-            <layer src="scalebar_kilometers/scalebar_km" legend="false" show-legend="false" fade="false" unfade="false"/>
         </group>
 
         <group title="Backgrounds" expand="true">

--- a/src/gm3/actionTypes.js
+++ b/src/gm3/actionTypes.js
@@ -123,3 +123,7 @@ export const PRINT = {
     REQUEST: 'PRINT_REQUEST',
     IMAGE: 'PRINT_IMAGE',
 };
+
+export const CONFIG = {
+    SET: 'GM3_CONFIG_SET',
+};

--- a/src/gm3/actions/config.js
+++ b/src/gm3/actions/config.js
@@ -1,0 +1,8 @@
+import { CONFIG } from '../actionTypes';
+
+export function setConfig(config) {
+    return {
+        type: CONFIG.SET,
+        payload: config,
+    };
+}

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -40,6 +40,7 @@ import * as serviceActions from './actions/service';
 
 import { parseCatalog } from './actions/catalog';
 import { parseToolbar } from './actions/toolbar';
+import { setConfig } from './actions/config';
 
 import catalogReducer from './reducers/catalog';
 import msReducer from './reducers/mapSource';
@@ -49,6 +50,7 @@ import queryReducer from './reducers/query';
 import uiReducer from './reducers/ui';
 import cursorReducer from './reducers/cursor';
 import printReducer from './reducers/print';
+import configReducer from './reducers/config';
 
 import Modal from './components/modal';
 
@@ -87,8 +89,11 @@ class Application {
             'query': queryReducer,
             'ui': uiReducer,
             'cursor': cursorReducer,
-            'print': printReducer
+            'print': printReducer,
+            'config': configReducer,
         }));
+
+        this.store.dispatch(setConfig(config));
 
         this.state = {};
 

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -54,6 +54,7 @@ import VectorLayer from 'ol/layer/Vector';
 import * as proj from 'ol/proj';
 
 import olControl from 'ol/control/Control';
+import olScaleLine from 'ol/control/ScaleLine';
 
 import olView from 'ol/View';
 import olMap from 'ol/Map';
@@ -77,6 +78,25 @@ import * as vectorLayer from './layers/vector';
 import * as bingLayer from './layers/bing';
 
 import { buildWfsQuery } from './layers/wfs';
+
+function getControls(mapConfig) {
+    const controls = [];
+
+    if (mapConfig.showZoom !== false) {
+        controls.push(new olZoomControl());
+    }
+    if (mapConfig.allowRotate !== false) {
+        controls.push(new olRotateControl());
+    }
+
+    const scaleLineConf = Object.assign({enabled: false, units: 'metric'}, mapConfig.scaleLine);
+    console.log('scaleLineConf', scaleLineConf, scaleLineConf.enabled);
+
+    if (scaleLineConf.enabled !== false) {
+        controls.push(new olScaleLine({units: scaleLineConf.units}));
+    }
+    return controls;
+}
 
 
 class Map extends React.Component {
@@ -919,10 +939,7 @@ class Map extends React.Component {
             layers: [this.selectionLayer],
             logo: false,
             view: new olView(view_params),
-            controls: [
-                new olZoomControl(),
-                new olRotateControl(),
-            ],
+            controls: getControls(this.props.config),
         });
 
         // when the map moves, dispatch an action
@@ -1312,10 +1329,16 @@ class Map extends React.Component {
 }
 
 function mapState(state) {
+    let config = {};
+    if (state.config && state.config.map) {
+        config = state.config.map;
+    }
+
     return {
         mapSources: state.mapSources,
         mapView: state.map,
-        queries: state.query
+        queries: state.query,
+        config,
     }
 }
 

--- a/src/gm3/jsts.js
+++ b/src/gm3/jsts.js
@@ -43,13 +43,16 @@ function bufferFeature(feature, meters) {
     // Start on null island.
     let pos_pt = [0, 0];
 
-    // TODO: Handle multi-poly and multi-line.
-    if (feature.geometry.type === 'Point') {
+    const gtype = feature.geometry.type;
+
+    if (gtype === 'Point') {
         pos_pt = feature.geometry.coordinates;
-    } else if(feature.geometry.type === 'LineString') {
+    } else if(gtype === 'MultiPoint' || gtype === 'LineString') {
+        pos_pt = feature.geometry.coordinates[0];
+    } else if(gtype === 'MultiLineString' || gtype === 'Polygon') {
         pos_pt = feature.geometry.coordinates[0][0];
-    } else if(feature.geometry.type === 'Polygon') {
-        pos_pt = feature.geometry.coordinates[0][0][0];
+    } else if(gtype === 'MuliPolygon') {
+        pos_pt = feature.geometry.cooredinates[0][0][0];
     }
 
     // find the feature's location in UTM space.

--- a/src/gm3/jsts.js
+++ b/src/gm3/jsts.js
@@ -30,11 +30,58 @@
  *
  */
 
-import turf_buffer from '@turf/buffer';
+import { BufferOp, GeoJSONReader, GeoJSONWriter } from 'turf-jsts';
 import turf_union from '@turf/union';
+import * as proj from 'ol/proj';
+import { jsonToGeom, geomToJson, getUtmZone } from './util';
 
 export function buffer(feature, meters) {
-    return turf_buffer(feature, meters, {units: 'meters'}).geometry;
+    return bufferFeature(feature, meters).geometry;
+}
+
+function bufferFeature(feature, meters) {
+    // Start on null island.
+    let pos_pt = [0, 0];
+
+    // TODO: Handle multi-poly and multi-line.
+    if (feature.geometry.type === 'Point') {
+        pos_pt = feature.geometry.coordinates;
+    } else if(feature.geometry.type === 'LineString') {
+        pos_pt = feature.geometry.coordinates[0][0];
+    } else if(feature.geometry.type === 'Polygon') {
+        pos_pt = feature.geometry.coordinates[0][0][0];
+    }
+
+    // find the feature's location in UTM space.
+    const utmZone = proj.get(getUtmZone(pos_pt));
+
+    // convert the geometry to an OL geometry
+    let geom = jsonToGeom(feature.geometry);
+
+    // project it to UTM
+    geom = geom.transform('EPSG:4326', utmZone);
+
+    // back again to JSON after reprojection
+    let meters_geojson = geomToJson(geom);
+
+    // JSTS buffer operation
+    const reader = new GeoJSONReader();
+    const jstsGeom = reader.read(meters_geojson);
+    const buffered = BufferOp.bufferOp(jstsGeom, meters);
+    const writer = new GeoJSONWriter();
+
+    // buffer by meters
+    meters_geojson = writer.write(buffered);
+
+    // back to 4326
+    const final_geom = jsonToGeom(meters_geojson).transform(utmZone, 'EPSG:4326');
+
+    // return the geometry wrapped in a feature.
+    return {
+        type: 'Feature',
+        properties: {},
+        geometry: geomToJson(final_geom),
+    };
 }
 
 
@@ -51,8 +98,7 @@ export function bufferAndUnion(features, meters) {
 
     for(let i = 0, ii = features.length; i < ii; i++) {
         // buffer the geometry.
-        const g = turf_buffer(features[i], meters, {units: 'meters'});
-
+        const g = bufferFeature(features[i], meters);
         // if the output geometry is still null, then set the
         //  first member to the new geometry
         if(geometry === null) {

--- a/src/gm3/reducers/config.js
+++ b/src/gm3/reducers/config.js
@@ -1,0 +1,10 @@
+import { CONFIG } from '../actionTypes';
+
+const DEFAULT_CONFIG = {};
+
+export default function(state = DEFAULT_CONFIG, action = {}) {
+    if (action.type === CONFIG.SET) {
+        return Object.assign({}, state, action.payload);
+    }
+    return state;
+}

--- a/tests/gm3/jsts.test.js
+++ b/tests/gm3/jsts.test.js
@@ -24,7 +24,16 @@
 
 import * as jsts from 'gm3/jsts';
 
+// this is necessary to configure the UTM projections
+import { configureProjections } from 'gm3/util';
+import { register } from 'ol/proj/proj4';
+import proj4 from 'proj4';
+
 describe('test basic jsts stuff', function() {
+    beforeEach(() => {
+        configureProjections(proj4);
+        register(proj4);
+    });
 
     it('buffers a point', function() {
         const point = {
@@ -36,7 +45,7 @@ describe('test basic jsts stuff', function() {
             }
         };
 
-        const polygon = jsts.buffer(point.geometry, 1);
+        const polygon = jsts.buffer(point, 1);
         expect(polygon.type).toBe('Polygon');
     });
 


### PR DESCRIPTION
1. Fixed the buffer calculation by doing the manual
   conversions in/out of traverse mercator.
2. Added the ability to enable openlayers scaleline
   indicator which was also correctly 'measuring' the
   distance represented on the map.
2b. I added a config reducer as a catch-all of app settings that
    may not necessarily be best interpreted by the mapbook.
    This may be fluid and should likely allow the user to change
    settings if a developer gets ambitious.
3. Dropped the misleading mapserver scalelines from the
   desktop demo mapbook.