### PR TITLE
Fix state bug with switching services

### DIFF
--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -58,7 +58,7 @@ import olScaleLine from 'ol/control/ScaleLine';
 
 import olView from 'ol/View';
 import olMap from 'ol/Map';
-import olXml from 'ol/xml';
+import * as olXml from 'ol/xml';
 
 import olCollection from 'ol/Collection';
 import olSelectInteraction from 'ol/interaction/Select';

--- a/src/gm3/components/serviceForm.js
+++ b/src/gm3/components/serviceForm.js
@@ -32,6 +32,8 @@ import BufferInput from './serviceInputs/buffer';
 
 import DrawTool from './drawTool';
 
+import { jsonEquals } from '../util';
+
 function renderServiceField(fieldDef, value, onChange) {
     let InputClass = TextInput;
 
@@ -53,20 +55,22 @@ function renderServiceField(fieldDef, value, onChange) {
     );
 }
 
+function getDefaultValues(serviceDef) {
+    // convert the values to a hash and memoize it into the state.
+    const values = {};
+    for (let i = 0, ii = serviceDef.fields.length; i < ii; i++) {
+        const field = serviceDef.fields[i];
+        values[field.name] = field.default;
+    }
+    return values;
+}
+
 
 export default class ServiceForm extends React.Component {
     constructor(props) {
         super(props);
-
-        // convert the values to a hash and memoize it into the state.
-        const values = {};
-        for (let i = 0, ii = this.props.serviceDef.fields.length; i < ii; i++) {
-            const field = this.props.serviceDef.fields[i];
-            values[field.name] = field.default;
-        }
-
         this.state = {
-            values,
+            values: getDefaultValues(this.props.serviceDef),
             validateFieldValuesResultMessage: null,
             lastService: null,
         };
@@ -88,10 +92,18 @@ export default class ServiceForm extends React.Component {
     }
 
     UNSAFE_componentWillUpdate(nextProps, nextState) {
-        if(this.state.lastService !== nextProps.serviceDef
-            && nextProps.serviceDef !== null) {
+        if (
+            nextProps.serviceDef !== null && (
+                !jsonEquals(this.state.lastService, nextProps.serviceDef) ||
+                !jsonEquals(this.props.serviceDef, nextProps.serviceDef)
+            )
+        ) {
             // 'rotate' the current service to the next services.
-            this.setState({lastService: nextProps.serviceDef, validateFieldValuesResultMessage: null});
+            this.setState({
+                values: getDefaultValues(nextProps.serviceDef),
+                lastService: nextProps.serviceDef,
+                validateFieldValuesResultMessage: null,
+            });
         }
     }
 

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -725,3 +725,15 @@ export function projectFeatures(features, srcProj, destProj) {
     //  the ".features" ensures an array is returned.
     return (GEOJSON_FORMAT.writeFeaturesObject(new_features)).features;
 }
+
+/**
+ * Compare two objects by their JSON strings.
+ *
+ * @param a First object to compare.
+ * @param b Second object to compare.
+ *
+ * @returns Boolean, true if they match, false if not.
+ */
+export function jsonEquals(a, b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+}


### PR DESCRIPTION
ServiceForm expected to be re-created when switching
services, this creates a better test and resets the values
to ensure they don't carry from incomplete service to incomplete service.