### PR TITLE
Fix selenium layer count check.

### DIFF
--- a/selenium/tests/basic.py
+++ b/selenium/tests/basic.py
@@ -12,5 +12,5 @@ def run(driver):
     elem = driver.find_element_by_id('catalog')
     layers = elem.find_elements_by_class_name('layer')
 
-    if len(layers) != 17:
+    if len(layers) < 10:
         raise Exception('Layers did not render!')


### PR DESCRIPTION
Was hard coded to 17, but sometimes the mapbook changes.  Allow to
pass when > 10, so this isn't so fragile.  The main goal is to see
if IE11 works at all.  More detailed tests can follow if needed.

ref: #391