### PR TITLE
Fixes for mobile branch

### DIFF
--- a/examples/mobile/index.html
+++ b/examples/mobile/index.html
@@ -1,15 +1,15 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <title>GeoMoose3 Mobile Demo</title>
     <!--
     /*
      * The MIT License (MIT)
      *
-     * Copyright (c) 2016 GeoMoose
+     * Copyright (c) 2016-2019 GeoMoose
      *
      * Permission is hereby granted, free of charge, to any person obtaining a copy
      * of this software and associated documentation files (the "Software"), to deal
@@ -31,48 +31,49 @@
      */
     -->
 
+
+    <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../geomoose/dist/css/geomoose.css">
-
-    <link rel="stylesheet" href="node_modules/jquery-mobile/dist/jquery.mobile.css">
-    <script type="text/javascript" src="node_modules/jquery/dist/jquery.js"></script>
-    <script type="text/javascript" src="node_modules/jquery-mobile/dist/jquery.mobile.min.js"></script>
-
     <link rel="stylesheet" href="mobile.css">
 </head>
 <body>
-    <div data-role="tabs" id="tabs">
-    <div data-role="navbar">
-        <ul id="tab-bar">
-            <li><a id="map-btn" href="#map"><i class="fa fa-map"></i></a></li>
-            <li><a href="#catalog"><i class="fa fa-book"></i></a></li>
-            <li><a href="#favorites"><i class="fa fa-star"></i></a></li>
-            <li><a href="#controls"><i class="fa fa-wrench"></i></a></li>
-            <li><a id="service-tab-btn" href="#service-tab"><i class="fa fa-table"></i></a></li>
-        </ul>
+    <div id="map"></div>
+
+    <div id="tabs">
+        <div id="catalog" class="tab-content hidden"></div>
+        <div id="favorites" class="tab-content"></div>
+        <div id="controls" class="tab-content">
+            <button id="findme-btn" class="btn btn-primary">
+                <i class="fa fa-map-marker" aria-hidden="true"></i><br>
+                Find Me
+            </button>
+            <button id="identify-btn" class="btn btn-primary">
+                <i class="fa fa-info-circle" aria-hidden="true"></i><br>
+                Identify
+            </button>
+        </div>
+        <div id="service-tab" class="tab-content"></div>
     </div>
 
-    <div id="map" class="ui-body-d ui-content tab-content"></div>
-    <div id="catalog" class="ui-body-d ui-content tab-content"></div>
-    <div id="favorites" class="ui-body-d ui-content tab-content"></div>
-    <div id="controls" class="ui-body-d ui-content tab-content">
-        <button id="findme-btn" class="service-btn ui-btn ui-btn-inline">
-            <i class="fa fa-map-marker" aria-hidden="true"></i><br>
-            Find Me
-        </button>
-        <button id="identify-btn" class="service-btn ui-btn ui-btn-inline">
-            <i class="fa fa-info-circle" aria-hidden="true"></i><br>
-            Identify
-        </button>
-    </div>
-
-    <div id="service-tab" class="ui-body-d ui-content tab-content"></div>
-    </div>
-
+    <nav class="navbar navbar-expand fixed-bottom navbar-dark bg-dark">
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav mr-auto nav-fill w-100">
+                <li class="nav-item active">
+                    <a class="nav-link" data-tab="map" title="Show map"><i class="fa fa-map"></i></a>
+                </li>
+                <li class="nav-item"><a class="nav-link" data-tab="catalog" title="Show catalog"><i class="fa fa-book"></i></a></li>
+                <li class="nav-item"><a class="nav-link" data-tab="favorites" title="Show favorites"><i class="fa fa-star"></i></a></li>
+                <li class="nav-item"><a class="nav-link" data-tab="controls" title="Show tools"><i class="fa fa-wrench"></i></a></li>
+                <li class="nav-item"><a class="nav-link" id="service-tab-btn" data-tab="service-tab" title="Show results"><i class="fa fa-table"></i></a></li>
+            </ul>
+        </div>
+    </nav>
+    <script type="text/javascript" src="node_modules/jquery/dist/jquery.slim.min.js"></script>
+    <script type="text/javascript" src="./node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script type="text/javascript" src="config.js"></script>
-    <script type="text/javascript" src="../geomoose/dist/geomoose.min.js"></script>
+    <script type="text/javascript" src="../geomoose/dist/geomoose.js"></script>
     <script type="text/javascript" src="../geomoose/dist/services/identify.js"></script>
     <script type="text/javascript" src="../geomoose/dist/services/findme.js"></script>
     <script type="text/javascript" src="mobile.js"></script>
 </body>
-
-
+</html>

--- a/examples/mobile/mobile.css
+++ b/examples/mobile/mobile.css
@@ -22,46 +22,38 @@
  * SOFTWARE.
  */
 
-#tabs {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    bottom: 0;
-}
-
-#tab-bar {
-    position: absolute;
-    top: 0;
-    left; 0;
-    width: 100%;
-}
-
-.tab-content {
-    position: absolute;
-    top: 2em; bottom: 0;
-    width: 100%;
-    overflow: auto;
-}
-
-#map {
-    background-color: white;
-    overflow: hidden;
-}
-
-#map .map {
+#map, #tabs {
     position: absolute;
     left: 0; width: 100%;
     top: 0; height: 100%;
+    background-color: white;
+}
+
+#map {
     overflow: hidden;
 }
 
-.catalog .searchbox {
-    top: 15px;
+#tabs {
+    display: none;
 }
 
-.ui-navbar {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
+#tabs.show {
+    display: block;
+}
+
+#tabs div {
+    /* ensure the tabs are above the map. */
+    z-index: 1;
+}
+
+#tabs .hidden {
+    display: none;
+}
+
+#controls {
+    padding: 16px;
+}
+
+#controls .btn {
+    margin-right: 8px;
 }

--- a/examples/mobile/mobile.js
+++ b/examples/mobile/mobile.js
@@ -33,7 +33,21 @@ var app = new gm3.Application({
 });
 
 function changeTab(tabName) {
-    $('#'+tabName+'-btn').trigger('click');
+    $('#tabs .tab-content')
+        .toggleClass('hidden', true);
+
+    $('#' + tabName)
+        .toggleClass('hidden', false);
+
+    $('#tabs')
+        .toggleClass('show', tabName !== 'map');
+
+    $('.navbar .nav-item')
+        .removeClass('active');
+
+    $('.navbar a[data-tab="' + tabName + '"]')
+        .parent()
+        .addClass('active');
 }
 
 app.uiUpdate = function(ui) {
@@ -56,12 +70,17 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     app.registerAction('findme', FindMeAction);
 
     app.add(gm3.components.Catalog, 'catalog');
-    app.add(gm3.components.Favorites, 'favorites');
-    app.add(gm3.components.ServiceManager, 'service-tab', /*hasServices*/ true);
     app.add(gm3.components.Map, 'map');
+    app.add(gm3.components.Favorites, 'favorites');
+    app.add(gm3.components.ServiceManager, 'service-tab', {
+        services: true
+    });
 
-    changeTab('map');
-
+    $('.nav-item .nav-link')
+        .on('click', evt => {
+            const tab = evt.currentTarget.getAttribute('data-tab');
+            changeTab(tab);
+        });
 
     // setup the Find Me button to find the user and
     //  go there on the map.
@@ -75,5 +94,8 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     // kick off an idenify.
     $('#identify-btn').on('click', function() {
         app.startService('identify');
+        changeTab('map');
     });
+
+    changeTab('map');
 });

--- a/examples/mobile/package.json
+++ b/examples/mobile/package.json
@@ -5,8 +5,9 @@
   "description": "GeoMoose 3 Mobile Application Demo",
   "main": "mobile.js",
   "dependencies": {
-    "jquery": "^2.1.4",
-    "jquery-mobile": "^1.4.1"
+    "bootstrap": "^4.4.1",
+    "jquery": "^3.4.1",
+    "popper": "^1.0.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/src/gm3/components/catalog/group.js
+++ b/src/gm3/components/catalog/group.js
@@ -31,10 +31,10 @@ export default class CatalogGroup extends React.Component {
         let classes = 'group';
         let is_open = '';
         if(group.expand) {
-            classes += ' expand';
+            classes += ' gm-expand';
             is_open = 'open';
         } else {
-            classes += ' collapse';
+            classes += ' gm-collapse';
         }
 
         return (

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -1328,16 +1328,11 @@ class Map extends React.Component {
 }
 
 function mapState(state) {
-    let config = {};
-    if (state.config && state.config.map) {
-        config = state.config.map;
-    }
-
     return {
         mapSources: state.mapSources,
         mapView: state.map,
         queries: state.query,
-        config,
+        config: state.config.map || {},
     }
 }
 

--- a/src/gm3/reducers/config.js
+++ b/src/gm3/reducers/config.js
@@ -1,6 +1,8 @@
 import { CONFIG } from '../actionTypes';
 
-const DEFAULT_CONFIG = {};
+const DEFAULT_CONFIG = {
+    map: {},
+};
 
 export default function(state = DEFAULT_CONFIG, action = {}) {
     if (action.type === CONFIG.SET) {

--- a/src/less/catalog.less
+++ b/src/less/catalog.less
@@ -49,7 +49,7 @@
 
 }
 
-.group.collapse {
+.group.gm-collapse {
     .children {
         max-height: 0 !important;
         overflow: hidden;
@@ -63,7 +63,7 @@
 }
 
 
-.group.expand {
+.group.gm-expand {
     .children {
         /*display: block;*/
         max-height: 2000px;

--- a/tests/gm3/components/catalog.test.js
+++ b/tests/gm3/components/catalog.test.js
@@ -129,9 +129,9 @@ describe('Catalog component tests', () => {
 
     it('toggles the group state', function() {
         catalog.find('.group-label').first().simulate('click');
-        expect(catalog.find('.expand').length).toBe(1);
+        expect(catalog.find('.gm-expand').length).toBe(1);
         catalog.find('.group-label').first().simulate('click');
-        expect(catalog.find('.collapse').length).toBe(1);
+        expect(catalog.find('.gm-collapse').length).toBe(1);
     });
 
     it('triggers a catalog search', function() {


### PR DESCRIPTION
1. Remove jquery mobile and switch to bootstrap
   for the useful css resets.
2. Fix a CSS namespace clash with collapse and expand.
3. Fix a bug found with the config. The map would go wonky
   if a configuration was not provided.
4. Cleaned up the logic for default map config settings.

refs: #399 #400 #401 