### PR TITLE
Add a scaleline to the print out

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -32,12 +32,14 @@
 var app = new gm3.Application({
     mapserver_url: CONFIG.mapserver_url,
     mapfile_root: CONFIG.mapfile_root,
+    /*
     map: {
         scaleLine: {
             enabled: true,
             units: 'imperial'
         }
     }
+    */
 });
 
 app.uiUpdate = function(ui) {

--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -32,14 +32,14 @@
 var app = new gm3.Application({
     mapserver_url: CONFIG.mapserver_url,
     mapfile_root: CONFIG.mapfile_root,
-    /*
+
     map: {
         scaleLine: {
             enabled: true,
             units: 'imperial'
         }
     }
-    */
+
 });
 
 app.uiUpdate = function(ui) {

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -145,6 +145,16 @@
     </map-source>
 
     <!--
+     * This map-source is used solely for testing geomose for scale issues
+     -->
+    <map-source name="grids" type="mapserver" up="true" down="true" title="Grids">
+        <file>./demo/grids/grids.map</file>
+        <param name="FORMAT" value="image/png"/>
+        <layer name="grid_1km"/>
+        <layer name="grid_1mile"/>
+    </map-source>
+
+    <!--
      * This map-source is used solely for testing geomose
      * with international characters.
      -->
@@ -404,6 +414,11 @@
             </group>
             <layer src="pipelines/pipelines"></layer>
             <layer title="Weather Radar" src="iastate/nexrad-n0r" />
+        </group>
+
+        <group title="Test Grids">
+            <layer title="1 km grid" src="grids/grid_1km"/>
+            <layer title="1 mile grid" src="grids/grid_1mile"/>
         </group>
 
         <group title="Backgrounds" expand="true">

--- a/src/gm3/components/print/printModal.js
+++ b/src/gm3/components/print/printModal.js
@@ -163,7 +163,7 @@ export default class PrintModal extends Modal {
         // add a scale line
         const scaleLine = state.config.map.scaleLine;
         if (scaleLine && scaleLine.enabled) {
-            const scaleInfo = getScalelineInfo(view, scaleLine.units || 'us');
+            const scaleInfo = getScalelineInfo(view, scaleLine.units || 'us', {multiplier: resolution});
             const pxToLayout = this.toPoints(1, 'px') / this.toPoints(1, layout.units);
             const margin = 12 * pxToLayout;
             const height = 12 * pxToLayout;

--- a/src/gm3/components/print/printModal.js
+++ b/src/gm3/components/print/printModal.js
@@ -47,6 +47,7 @@ import { printed } from '../../actions/print';
 import DefaultLayouts from './printLayouts';
 
 import GeoPdfPlugin from './geopdf';
+import { getScalelineInfo } from '../scaleline';
 
 
 export default class PrintModal extends Modal {
@@ -82,7 +83,7 @@ export default class PrintModal extends Modal {
     }
 
 
-    addText(doc, def) {
+    addText(doc, def, options = {}) {
         // these are the subsitution strings for the map text elements
         const date = new Date();
         const subst_dict = {
@@ -96,7 +97,7 @@ export default class PrintModal extends Modal {
         const defaults = {
             size: 13,
             color: [0, 0, 0],
-            font: 'Arial',
+            font: 'helvetica',
             fontStyle: 'normal'
         };
 
@@ -112,7 +113,7 @@ export default class PrintModal extends Modal {
         // and the font face.
         doc.setFont(full_def.font, full_def.fontStyle);
         // then mark the face.
-        doc.text(full_def.x, full_def.y, Mark.up(full_def.text, subst_dict));
+        doc.text(full_def.x, full_def.y, Mark.up(full_def.text, subst_dict), options);
     }
 
     /* Embed an image in the PDF
@@ -130,13 +131,14 @@ export default class PrintModal extends Modal {
     /* Wraps addImage specifically for the map.
      */
     addMapImage(doc, def, layout) {
+        const state = this.props.store.getState();
+
         // this is not a smart component and it doesn't need to be,
         //  so sniffing the state for the current image is just fine.
-        const image_data = this.props.store.getState().print.printData;
-        this.addImage(doc, Object.assign({}, def, {image_data: image_data}));
+        this.addImage(doc, Object.assign({}, def, {image_data: state.print.printData}));
 
         // construct the extents from the map
-        const map_view = this.props.store.getState().map;
+        const map_view = state.map;
         // TODO: get this from state
         const map_proj = 'EPSG:3857';
 
@@ -158,6 +160,38 @@ export default class PrintModal extends Modal {
             pdf_extents[i] = this.toPoints(pdf_extents[i], u);
         }
 
+        // add a scale line
+        const scaleLine = state.config.map.scaleLine;
+        if (scaleLine && scaleLine.enabled) {
+            const scaleInfo = getScalelineInfo(view, scaleLine.units || 'us');
+            const pxToLayout = this.toPoints(1, 'px') / this.toPoints(1, layout.units);
+            const margin = 12 * pxToLayout;
+            const height = 12 * pxToLayout;
+            this.addDrawing(doc, {
+                type: 'rect',
+                filled: true,
+                // place this in the lower left corner of the map
+                x: def.x + margin,
+                y: def.y + def.height - margin - height,
+                // width info comes as pixels, this
+                //  should convert the width
+                width: scaleInfo.width / 72,
+                height,
+                strokeWidth: 0,
+                fill: [178, 196, 219],
+            });
+
+            this.addText(doc, {
+                x: def.x + margin + 2 * pxToLayout,
+                y: def.y + def.height - margin - height / 2,
+                text: scaleInfo.label,
+                size: 12,
+                color: [238, 238, 238],
+            }, {
+                baseline: 'middle',
+            });
+        }
+
         doc.setGeoArea(pdf_extents, map_extents);
     }
 
@@ -170,17 +204,20 @@ export default class PrintModal extends Modal {
         let style = 'S';
         if(def.filled) {
             style = 'DF';
+            const fill = def.fill ? def.fill : [255, 255, 255];
+            doc.setFillColor(fill[0], fill[1], fill[2]);
         }
 
-        // set the colors
-        const stroke = def.stroke ? def.stroke : [0, 0, 0];
-        const fill = def.fill ? def.fill : [255, 255, 255];
-        doc.setDrawColor(stroke[0], stroke[1], stroke[2]);
-        doc.setFillColor(fill[0], fill[1], fill[2]);
-
         // set the stroke width
-        const stroke_width = def.strokeWidth ? def.strokeWidth : 1;
-        doc.setLineWidth(stroke_width);
+        const stroke_width = def.strokeWidth !== undefined ? def.strokeWidth : this.toPoints(1, 'px');
+        if (stroke_width > 0) {
+            const stroke = def.stroke ? def.stroke : [0, 0, 0];
+            doc.setLineWidth(stroke_width);
+            doc.setDrawColor(stroke[0], stroke[1], stroke[2]);
+        } else {
+            style = 'F';
+            doc.setLineWidth(0);
+        }
 
         // draw the shape.
         if(def.type === 'rect') {
@@ -239,10 +276,6 @@ export default class PrintModal extends Modal {
         }
         // new PDF document
         const doc = new jsPDF(layout.orientation, layout.units, layout.page);
-
-        // add some fonts
-        doc.addFont('Arial', 'Arial', 'normal');
-        doc.addFont('Arial-Bold', 'Arial', 'bold');
 
         // iterate through the elements of the layout
         //  and place them in the document.

--- a/src/gm3/components/scaleline.js
+++ b/src/gm3/components/scaleline.js
@@ -1,5 +1,8 @@
 /**
- * @module ol/control/ScaleLine
+ * This code is a refactored version of what comes in the
+ * ol/control/ScaleLine. It uses much of the same logic but
+ * instead of rendering the scale line it returns the metadata
+ * for rendering.
  */
 import {getPointResolution, METERS_PER_UNIT} from 'ol/proj';
 import ProjUnits from 'ol/proj/Units';

--- a/src/gm3/components/scaleline.js
+++ b/src/gm3/components/scaleline.js
@@ -24,6 +24,7 @@ const LEADING_DIGITS = [1, 2, 5];
 
 const DEFAULT_OPTIONS = {
     minWidth: 64,
+    multiplier: 1,
 };
 
 export function getScalelineInfo(viewState, units, inOpts = {}) {
@@ -39,7 +40,7 @@ export function getScalelineInfo(viewState, units, inOpts = {}) {
     }
     const resolution = viewState.getResolution();
     let pointResolution =
-        getPointResolution(projection, resolution, center, pointResolutionUnits);
+        getPointResolution(projection, resolution * options.multiplier, center, pointResolutionUnits);
     if (projection.getUnits() !== ProjUnits.DEGREES && projection.getMetersPerUnit()
       && pointResolutionUnits === ProjUnits.METERS) {
         pointResolution *= projection.getMetersPerUnit();

--- a/src/gm3/components/scaleline.js
+++ b/src/gm3/components/scaleline.js
@@ -1,0 +1,135 @@
+/**
+ * @module ol/control/ScaleLine
+ */
+import {getPointResolution, METERS_PER_UNIT} from 'ol/proj';
+import ProjUnits from 'ol/proj/Units';
+
+/**
+ * Units for the scale line. Supported values are `'degrees'`, `'imperial'`,
+ * `'nautical'`, `'metric'`, `'us'`.
+ * @enum {string}
+ */
+const Units = {
+    DEGREES: 'degrees',
+    IMPERIAL: 'imperial',
+    NAUTICAL: 'nautical',
+    METRIC: 'metric',
+    US: 'us'
+};
+
+const LEADING_DIGITS = [1, 2, 5];
+
+const DEFAULT_OPTIONS = {
+    minWidth: 64,
+};
+
+export function getScalelineInfo(viewState, units, inOpts = {}) {
+    const options = Object.assign({}, DEFAULT_OPTIONS, inOpts);
+
+    const center = viewState.getCenter();
+    const projection = viewState.getProjection();
+    const pointResolutionUnits = units === Units.DEGREES ?
+        ProjUnits.DEGREES :
+        ProjUnits.METERS;
+    if (!projection) {
+        return {label: '', width: 0, error: 'no-projection'};
+    }
+    const resolution = viewState.getResolution();
+    let pointResolution =
+        getPointResolution(projection, resolution, center, pointResolutionUnits);
+    if (projection.getUnits() !== ProjUnits.DEGREES && projection.getMetersPerUnit()
+      && pointResolutionUnits === ProjUnits.METERS) {
+        pointResolution *= projection.getMetersPerUnit();
+    }
+
+    let nominalCount = options.minWidth * pointResolution;
+    let suffix = '';
+    if (units === Units.DEGREES) {
+        const metersPerDegree = METERS_PER_UNIT[ProjUnits.DEGREES];
+        if (projection.getUnits() === ProjUnits.DEGREES) {
+            nominalCount *= metersPerDegree;
+        } else {
+            pointResolution /= metersPerDegree;
+        }
+        if (nominalCount < metersPerDegree / 60) {
+            // seconds
+            suffix = '\u2033';
+            pointResolution *= 3600;
+        } else if (nominalCount < metersPerDegree) {
+            // minutes
+            suffix = '\u2032';
+            pointResolution *= 60;
+        } else {
+            // degrees
+            suffix = '\u00b0';
+        }
+    } else if (units === Units.IMPERIAL) {
+        if (nominalCount < 0.9144) {
+            suffix = 'in';
+            pointResolution /= 0.0254;
+        } else if (nominalCount < 1609.344) {
+            suffix = 'ft';
+            pointResolution /= 0.3048;
+        } else {
+            suffix = 'mi';
+            pointResolution /= 1609.344;
+        }
+    } else if (units === Units.NAUTICAL) {
+        pointResolution /= 1852;
+        suffix = 'nm';
+    } else if (units === Units.METRIC) {
+        if (nominalCount < 0.001) {
+            suffix = 'μm';
+            pointResolution *= 1000000;
+        } else if (nominalCount < 1) {
+            suffix = 'mm';
+            pointResolution *= 1000;
+        } else if (nominalCount < 1000) {
+            suffix = 'm';
+        } else {
+            suffix = 'km';
+            pointResolution /= 1000;
+        }
+    } else if (units === Units.US) {
+        if (nominalCount < 0.9144) {
+            suffix = 'in';
+            pointResolution *= 39.37;
+        } else if (nominalCount < 1609.344) {
+            suffix = 'ft';
+            pointResolution /= 0.30480061;
+        } else {
+            suffix = 'mi';
+            pointResolution /= 1609.3472;
+        }
+    } else {
+        return {
+            label: '',
+            width: 0,
+            error: 'bad-units',
+        };
+    }
+
+    let i = 3 * Math.floor(
+        Math.log(options.minWidth * pointResolution) / Math.log(10));
+    let count, width;
+    while (true) {
+        count = LEADING_DIGITS[((i % 3) + 3) % 3] *
+          Math.pow(10, Math.floor(i / 3));
+        width = Math.round(count / pointResolution);
+        if (isNaN(width)) {
+            return {
+                label: '',
+                width: 0,
+                error: 'width-is-nan',
+            };
+        } else if (width >= options.minWidth) {
+            break;
+        }
+        ++i;
+    }
+
+    return {
+        label: `${count} ${suffix}`,
+        width,
+    }
+}

--- a/src/gm3/components/serviceForm.js
+++ b/src/gm3/components/serviceForm.js
@@ -32,8 +32,6 @@ import BufferInput from './serviceInputs/buffer';
 
 import DrawTool from './drawTool';
 
-import { jsonEquals } from '../util';
-
 function renderServiceField(fieldDef, value, onChange) {
     let InputClass = TextInput;
 


### PR DESCRIPTION
Draws a scaleline on the PDF when configured
to do so. The settings are the same ones used
to render the scaleline for the map.

refs: #398 