### PR TITLE
Add cross-origin parameter to WMS layer in demo

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -164,6 +164,7 @@
         <layer name="nexrad-n0r"/>
         <param name="FORMAT" value="image/png"/>
         <param name="TRANSPARENT" value="TRUE"/>
+        <param name="cross-origin" value="anonymous"/>
     </map-source>
 
 


### PR DESCRIPTION
This should enable the demo print option to work with the demo WMS now that the cross-origin param is respected (https://github.com/geomoose/gm3/issues/406)