### PR TITLE
Fix issue with disappearing tool interaction

### DIFF
--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -356,6 +356,7 @@ class ServiceManager extends React.Component {
 
             if (service_def &&
                 service_def.tools &&
+                this.props.map.interactionType == null &&
                 service_def.tools.default !== this.props.map.interactionType) {
                 // TODO: The last tool state for a service should be saved so
                 //       as much interaction state as possible can be restored.

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -353,6 +353,16 @@ class ServiceManager extends React.Component {
         } else {
             const service_name = this.state.lastService;
             const service_def = nextProps.services[service_name];
+
+            if (service_def &&
+                service_def.tools &&
+                service_def.tools.default !== this.props.map.interactionType) {
+                // TODO: The last tool state for a service should be saved so
+                //       as much interaction state as possible can be restored.
+                // restore the default tool when re-clicking the service.
+                this.props.changeDrawTool(service_def.tools.default);
+            }
+
             // if this service has 'autoGo' and the feature is different
             //  than the last one, then execute the query.
             if(service_def && service_def.autoGo) {

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -356,7 +356,7 @@ class ServiceManager extends React.Component {
 
             if (service_def &&
                 service_def.tools &&
-                this.props.map.interactionType == null &&
+                this.props.map.interactionType === null &&
                 service_def.tools.default !== this.props.map.interactionType) {
                 // TODO: The last tool state for a service should be saved so
                 //       as much interaction state as possible can be restored.


### PR DESCRIPTION
When "End Drawing" is clicked it sets the interactionType to null.
However, when re-clicking the same service, this was causing a weird
null-state to be displayed to the user. They had started the service
but no drawing tool would be selected.

This restores the drawing tool to the default no matter what.