### PR TITLE
Measure point: Display correct USNG resolution

### DIFF
--- a/src/gm3/components/measure.js
+++ b/src/gm3/components/measure.js
@@ -250,7 +250,7 @@ export class MeasureTool extends Component {
                 </div>
             );
         } else if (g.type === 'Point') {
-            return ( <CoordinateDisplay coords={ g.coordinates } projections={ this.props.pointProjections } /> );
+            return ( <CoordinateDisplay coords={ g.coordinates } projections={ this.props.pointProjections } resolution={ this.props.map.resolution } /> );
         } else if (g.type === 'LineString') {
             return this.renderSegments(g);
         } else if (g.type === 'Polygon') {


### PR DESCRIPTION
`<CoordinateDisplay>`, used to display the results of measure point,
needs the resolution parameter to know how many digits to display
for USNG coordinates.  Otherwise, it defaults to displaying no
digits (100km resolution).