### PR TITLE
Fix identify button on mobile

### DIFF
--- a/examples/mobile/mobile.js
+++ b/examples/mobile/mobile.js
@@ -93,7 +93,7 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
 
     // kick off an idenify.
     $('#identify-btn').on('click', function() {
-        app.startService('identify');
+        app.startService('identify', {changeTool: 'Point'});
         changeTab('map');
     });
 

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -644,6 +644,9 @@ class Application {
      */
     startService(serviceName, options) {
         this.store.dispatch(serviceActions.startService(serviceName));
+        if (options.changeTool) {
+            this.store.dispatch(mapActions.changeTool(options.changeTool));
+        }
     }
 
     /** Handle updating the UI, does nothing in vanilla form.


### PR DESCRIPTION
Previous fix for starting a service's default tool broke
the implementation for mobile. This fixes it.

refs: #399