### PR TITLE
Fix for empty geometry losing tools

### DIFF
--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -644,7 +644,7 @@ class Application {
      */
     startService(serviceName, options) {
         this.store.dispatch(serviceActions.startService(serviceName));
-        if (options.changeTool) {
+        if (options && options.changeTool) {
             this.store.dispatch(mapActions.changeTool(options.changeTool));
         }
     }

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -111,8 +111,9 @@ function SelectService(Application, options) {
             // throw up this handy dialog.
             var msg = 'A selection geometry is required for this query.';
             var service_name = this.name;
+            var self = this;
             var on_close = function() {
-                Application.startService(service_name);
+                Application.startService(service_name, {changeTool: self.tools.default});
             };
 
             Application.alert('selection-required', msg, on_close);


### PR DESCRIPTION
1. Add a sanity check to `startService` to prevent an error when
   a caller fails to pass in options.
2. Add the `changeTool` option to the `startService` call in
   Select when there is an empty geometry.

refs: #470