### PR TITLE
Fix for missing IE11 Fetch Polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11294,12 +11294,6 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
-    "skeleton-less": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/skeleton-less/-/skeleton-less-2.0.1.tgz",
-      "integrity": "sha1-GLAdPzuz2jAGTx3o8OuLichYGnk=",
-      "dev": true
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -13247,6 +13241,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "uuid": "^3.2.1",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
-    "webpack-dev-server": "^3.10.1"
+    "webpack-dev-server": "^3.10.1",
+    "whatwg-fetch": "^3.0.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = env => {
         devtool: isDevelopment ? 'eval-source-map' : undefined,
         entry: [
             'babel-polyfill',
+            'whatwg-fetch',
             './src/index.js'
         ],
         resolve: {


### PR DESCRIPTION
Adds the standard whatwg-fetch polyfill to fix the error
on IE11 with calling fetch.

refs: #472