### PR TITLE
Fix default state of activeSource for select

### DIFF
--- a/src/gm3/components/drawTool.js
+++ b/src/gm3/components/drawTool.js
@@ -72,8 +72,7 @@ class DrawTool extends React.Component {
     componentDidMount() {
         // if starting up with the select tool,
         //  ensure there is a valid active layer.
-        if (this.props.geomType === 'Select') {
-            // this.changeSelectLayer(this.props.selectableLayers[0]);
+        if (this.props.interactionType === 'Select' && this.props.geomType === 'Select') {
             const firstLayer = this.props.selectableLayers[0];
             this.setState({selectLayer: firstLayer});
             this.props.onChange('Select', firstLayer);

--- a/src/gm3/components/drawTool.js
+++ b/src/gm3/components/drawTool.js
@@ -36,7 +36,6 @@ class DrawTool extends React.Component {
     constructor(props) {
         super(props);
 
-        this.changeDrawTool = this.changeDrawTool.bind(this);
         this.changeSelectLayer = this.changeSelectLayer.bind(this);
 
         this.state = {
@@ -47,10 +46,6 @@ class DrawTool extends React.Component {
             this.state.selectLayer = this.props.selectableLayers[0];
         }
 
-    }
-
-    changeDrawTool(type) {
-        this.props.store.dispatch(changeTool(type, this.state.selectLayer));
     }
 
     changeSelectLayer(event) {
@@ -72,6 +67,17 @@ class DrawTool extends React.Component {
         }
 
         return options;
+    }
+
+    componentDidMount() {
+        // if starting up with the select tool,
+        //  ensure there is a valid active layer.
+        if (this.props.geomType === 'Select') {
+            // this.changeSelectLayer(this.props.selectableLayers[0]);
+            const firstLayer = this.props.selectableLayers[0];
+            this.setState({selectLayer: firstLayer});
+            this.props.onChange('Select', firstLayer);
+        }
     }
 
     render() {


### PR DESCRIPTION
If the Select tool is the default (pick-a-feature-from-alayer)
then it was not setting the appropriate default interactive layer.

This checks to ensure that when Select is the default it will
use the first layer that is active.

refs: #438