### PR TITLE
Update to ol-mapbox-style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,18 +215,26 @@
       "dev": true
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-9.0.1.tgz",
-      "integrity": "sha512-j3qgGIk1LDYlDOo7VGEge5o/rHkhW4Z+w9fSdgbq8ZEg8KkXdxlDZeUbeaO14s4n0ML6Nz7hSF8JNlwYXl8R7A==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.13.1.tgz",
+      "integrity": "sha512-qMELFs9Ky+v2OFS69tqf3l+4m3lJpGlE7hcyPH7rRoEMR5I4KFYIldzdyV4XHT3pnPjKAgtUd2ng2vgQqji7DA==",
       "dev": true,
       "requires": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
         "csscolorparser": "~1.0.2",
-        "jsonlint-lines-primitives": "~1.6.0",
-        "lodash.isequal": "^3.0.4",
+        "json-stringify-pretty-compact": "^2.0.0",
         "minimist": "0.0.8",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
       }
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=",
+      "dev": true
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
@@ -531,12 +539,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
-    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -664,12 +666,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
       "dev": true
     },
     "anymatch": {
@@ -2632,25 +2628,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "chalk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        }
-      }
-    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -3582,6 +3559,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
+    },
+    "elm-pep": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/elm-pep/-/elm-pep-1.0.6.tgz",
+      "integrity": "sha512-1DJ6ReFk8+GtgoqRiEhBo28K69Rxe9Bfc7h16+1VMQT2KlCuPBYj5W33OYa2AZpqkuqCBLhcNzO10zxJVakapA==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -5809,12 +5792,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -8390,16 +8367,6 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonlint-lines-primitives": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jsonlint-lines-primitives/-/jsonlint-lines-primitives-1.6.0.tgz",
-      "integrity": "sha1-u4n2DIubYS/ZE92qI2ZJuEDYZhE=",
-      "dev": true,
-      "requires": {
-        "JSV": ">= 4.0.x",
-        "nomnom": ">= 1.5.x"
-      }
-    },
     "jspdf": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-1.5.3.tgz",
@@ -8588,29 +8555,6 @@
       "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
       "dev": true
     },
-    "lodash._baseisequal": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
-      "dev": true,
-      "requires": {
-        "lodash.isarray": "^3.0.0",
-        "lodash.istypedarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -8622,45 +8566,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.isequal": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
-      "integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
-      "dev": true,
-      "requires": {
-        "lodash._baseisequal": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0"
-      }
-    },
-    "lodash.istypedarray": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8754,30 +8659,6 @@
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg==",
       "dev": true
-    },
-    "mapbox-to-ol-style": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/mapbox-to-ol-style/-/mapbox-to-ol-style-3.4.3.tgz",
-      "integrity": "sha512-XdVu4qWmaECBTzlc4RL/c3+uuXHkfHbx+63sD3ZkGGmB2HqR7BXzEc/9/MCp3NsLxxw1stjvlFp+y6B0A/80oA==",
-      "dev": true,
-      "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^9.0.1",
-        "mapbox-to-css-font": "^2.1.0",
-        "ol": "^4.6.4"
-      },
-      "dependencies": {
-        "ol": {
-          "version": "4.6.5",
-          "resolved": "https://registry.npmjs.org/ol/-/ol-4.6.5.tgz",
-          "integrity": "sha512-FtXsY3WY07c5vEP53rUkkw3jN7orcmg07lbmTfeS2hGyIZ0Noy1xC5urP+n6XTggnQZv0NlOkAt9lxNEmAQWQw==",
-          "dev": true,
-          "requires": {
-            "pbf": "3.1.0",
-            "pixelworks": "1.1.0",
-            "rbush": "2.0.1"
-          }
-        }
-      }
     },
     "mapskin": {
       "version": "1.0.0",
@@ -9221,16 +9102,6 @@
         }
       }
     },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -9543,45 +9414,36 @@
       "dev": true
     },
     "ol": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-5.3.3.tgz",
-      "integrity": "sha512-7eU4x8YMduNcED1D5wI+AMWDRe7/1HmGfsbV+kFFROI9RNABU/6n4osj6Q3trZbxxKnK2DSRIjIRGwRHT/Z+Ww==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.3.1.tgz",
+      "integrity": "sha512-cSSYizzUJQ7AhFSrLPAKopjDXPCHtJsXSmjf3xutPG+iyBeD9IOepQGSgpOSZavPI1gsYh9wowiH+NZwVJ/NYQ==",
       "dev": true,
       "requires": {
-        "pbf": "3.1.0",
+        "elm-pep": "^1.0.4",
+        "pbf": "3.2.1",
         "pixelworks": "1.1.0",
-        "rbush": "2.0.2"
-      },
-      "dependencies": {
-        "rbush": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
-          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
-          "dev": true,
-          "requires": {
-            "quickselect": "^1.0.1"
-          }
-        }
+        "rbush": "^3.0.1"
       }
     },
     "ol-mapbox-style": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-3.9.0.tgz",
-      "integrity": "sha512-AU7hGx4ggC+iJROWd4vN5S/46F93JLWW25yvYbuB10IJ9UKHbql3Ny2aOwnWAMU1RN6JHAx/ged+Zj0y4eX7CQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.1.1.tgz",
+      "integrity": "sha512-0Hgz2BX2tWe1ZNPMLpJkLdm3XI6ILrFbgmJIvdrlDYRce2ul1mXLmkJmbyLFs2tozsBJDcPJmI55UsKbiKg6ow==",
       "dev": true,
       "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^13.6.0",
-        "mapbox-to-css-font": "^2.2.0",
+        "@mapbox/mapbox-gl-style-spec": "13.13.0",
+        "mapbox-to-css-font": "^2.4.0",
         "webfont-matcher": "^1.1.0"
       },
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": {
-          "version": "13.10.1",
-          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.10.1.tgz",
-          "integrity": "sha512-JBpIJHXyjst75uuVyTX3zMFLy1qPFCwDNa4zAfDYOK+KOIFPSCxd5wzVEnBYdNHk/7lf0XDom5l5bN4wx1Hevw==",
+          "version": "13.13.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.13.0.tgz",
+          "integrity": "sha512-PBXa/Bw2G87NZckBZqY3omI3THF5MYQQY5B1IZWVLI7Ujsy149cjC8Sm1Ub1BgAnyslepdjtwWVS43IOjVYmUw==",
           "dev": true,
           "requires": {
             "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+            "@mapbox/point-geometry": "^0.1.0",
             "@mapbox/unitbezier": "^0.0.0",
             "csscolorparser": "~1.0.2",
             "json-stringify-pretty-compact": "^2.0.0",
@@ -9946,13 +9808,13 @@
       }
     },
     "pbf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
-      "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "dev": true,
       "requires": {
-        "ieee754": "^1.1.6",
-        "resolve-protobuf-schema": "^2.0.0"
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "pbkdf2": {
@@ -10180,9 +10042,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA==",
       "dev": true
     },
     "proxy-addr": {
@@ -10291,9 +10153,9 @@
       "dev": true
     },
     "quickselect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "dev": true
     },
     "raf": {
@@ -10392,12 +10254,12 @@
       }
     },
     "rbush": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.1.tgz",
-      "integrity": "sha1-TPrKKMMGS8DudUMaG3mZDode76k=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
       "dev": true,
       "requires": {
-        "quickselect": "^1.0.0"
+        "quickselect": "^2.0.0"
       }
     },
     "react": {
@@ -12601,12 +12463,6 @@
           }
         }
       }
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "jest": {
     "testURL": "http://localhost",
     "transformIgnorePatterns": [
-      "node_modules/(?!ol|mapbox|jsts)"
+      "node_modules/(?!ol|jsts)"
     ],
     "moduleDirectories": [
       "./src",
@@ -56,7 +56,7 @@
     "test": "tests"
   },
   "devDependencies": {
-    "@mapbox/mapbox-gl-style-spec": "^9.0.0",
+    "@mapbox/mapbox-gl-style-spec": "^13.6.0",
     "@turf/buffer": "^5.1.5",
     "@turf/union": "^5.0.0",
     "babel-cli": "^6.26.0",
@@ -84,13 +84,12 @@
     "jspdf": "^1.3.5",
     "jsts": "~1.4.0",
     "less": "^3.10.3",
-    "mapbox-to-ol-style": "^3.4.3",
     "mapskin": "^1.0.0",
     "markup-js": "^1.5.21",
     "md5": "^2.2.1",
     "npm-run-all": "^4.1.5",
-    "ol": "^5.3.0",
-    "ol-mapbox-style": "^3.5.0",
+    "ol": "^6.0.0",
+    "ol-mapbox-style": "^6.1.0",
     "papaparse": "^4.3.7",
     "proj4": "^2.4.3",
     "react": "^16.3.0",

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -32,14 +32,21 @@ import * as util from '../util';
 
 let MS_Z_INDEX = 100000;
 
+const SOURCE_DEFAULTS = {
+    opacity: 1.0,
+};
+
 /** Add a map-source using a MapSource
  *  object.
  */
-export function add(mapSource) {
-    if(typeof(mapSource.zIndex) !== 'number') {
-        mapSource.zIndex = MS_Z_INDEX;
+export function add(mapSourceIn) {
+    if(typeof(mapSourceIn.zIndex) !== 'number') {
+        mapSourceIn.zIndex = MS_Z_INDEX;
         MS_Z_INDEX--;
     }
+
+    const mapSource = Object.assign({}, SOURCE_DEFAULTS, mapSourceIn);
+
     return {
         type: MAPSOURCE.ADD,
         mapSource

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -178,7 +178,7 @@ class Application {
             label: 'Results',
             selectable: true,
             style: results_style,
-            filter: null,
+            // filter: null,
         }));
 
         // the "hot" layer shows the features as red on the map,
@@ -188,7 +188,7 @@ class Application {
             name: 'results-hot',
             on: true,
             style: hot_style,
-            filter: ['==', 'displayClass', 'hot']
+            filter: ['==', 'displayClass', 'hot'],
         }));
     }
 

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -36,8 +36,6 @@ import ReactResizeDetector from 'react-resize-detector';
 import uuid from 'uuid';
 import md5 from 'md5/md5';
 
-import applyStyleFunction from 'mapbox-to-ol-style';
-
 import * as mapSourceActions from '../actions/mapSource';
 import * as mapActions from '../actions/map';
 
@@ -227,7 +225,7 @@ class Map extends React.Component {
             'INFO_FORMAT': 'application/vnd.ogc.gml'
         };
 
-        const info_url = src.getGetFeatureInfoUrl(coords, view.resolution, map_projection.getCode(), params);
+        const info_url = src.getFeatureInfoUrl(coords, view.resolution, map_projection.getCode(), params);
         fetch(info_url, {
             headers: {
                 'Access-Control-Request-Headers': '*',
@@ -875,21 +873,13 @@ class Map extends React.Component {
             source: src_selection,
         });
 
-        applyStyleFunction(this.selectionLayer, {
-            'version': 8,
-            'layers': [
-                {
-                    'id': 'dummy',
-                    'source': 'dummy-source',
-                    'paint': this.props.selectionStyle,
-                }
+        // Fake a GeoMoose style source + layer definition
+        //  to bootstrap the style
+        vectorLayer.applyStyle(this.selectionLayer, {
+            layers: [
+                {on: true, style: this.props.selectionStyle},
             ],
-            'dummy-source': [
-                {
-                    'type': 'vector'
-                }
-            ]
-        }, 'dummy-source');
+        });
 
         // whenever a feature has been added or changed on the selection layer,
         //  reflect that in the selection.
@@ -1343,7 +1333,7 @@ function mapState(state) {
         mapView: state.map,
         queries: state.query,
         config: state.config.map || {},
-        selectionStyle: state.config.selectionStyle,
+        selectionStyle: state.config.selectionStyle || {},
     }
 }
 

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -26,7 +26,7 @@ import Request from 'reqwest';
 
 import GeoJSONFormat from 'ol/format/GeoJSON';
 
-import createFilter from '@mapbox/mapbox-gl-style-spec/feature_filter';
+import {featureFilter as createFilter} from '@mapbox/mapbox-gl-style-spec';
 
 /** Collection of handy functions
  */
@@ -318,11 +318,11 @@ export function filterFeatures(features, filter, inverse = true) {
     let filter_function = function() { return true; };
 
     if (filter !== undefined && filter !== null ) {
-        filter_function = createFilter(['all'].concat(filter));
+        filter_function = createFilter(['all'].concat(filter)).filter;
     }
 
     for(const feature of features) {
-        if(inverse !== filter_function(feature)) {
+        if(inverse !== filter_function({zoom: 15}, feature)) {
             new_features.push(feature);
         }
     }


### PR DESCRIPTION
Previous Mapbox GL to OL style library was deprecated.
This new version is more full featured. Updated the
vector layer class to also check the spec for divving up
the properties between paint and layout sections.