### PR TITLE
Fix for tab-toggler background color

### DIFF
--- a/examples/desktop/tabs.css
+++ b/examples/desktop/tabs.css
@@ -45,6 +45,9 @@
     z-index: 1000;
     transform: rotate(0deg);
     transition: left ease 500ms, transform ease 500ms;
+    border-radius: 10px;
+    background-color: white;
+    line-height: 10px;
 }
 
 .tabs-closed .tab-toggler {


### PR DESCRIPTION
Style updates meant the tab-togglers "arrow" was transparent
and was causing but click-ability issues and visibility issues.

This MR adds the background that fixes that.

Supersedes #447 