### PR TITLE
Fix broken keepAlive setting and add it to Select.

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -146,6 +146,7 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     app.registerService('select', SelectService, {
         // set the default layer
         defaultLayer: 'vector-parcels/parcels',
+        keepAlive: true,
     });
 
     app.registerService('buffer-select', SelectService, {

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -837,7 +837,6 @@ class Map extends React.Component {
             }], 'EPSG:4326', 'EPSG:3857')[0];
         }
 
-
         // the selection feature(s) are the original, as-drawn feature.
         this.props.setSelectionFeatures(features);
 
@@ -1225,13 +1224,6 @@ class Map extends React.Component {
             }
         }
 
-        // this will cause the active drawing tool to *stop*
-        //  when the service changes.
-        if(this.props.queries.service !== null
-           && this.props.queries.service !== prevProps.queries.service) {
-            this.stopDrawing();
-        }
-
         // handle out of loop buffer distance changes
         if (this.selectionLayer) {
             if (this.props.selectionBuffer !== prevProps.selectionBuffer) {
@@ -1263,7 +1255,7 @@ class Map extends React.Component {
 
             if (interactionType !== prevProps.mapView.interactionType
                || this.props.mapView.activeSource !== prevProps.mapView.activeSource
-               || this.props.mapView.interactionType !== this.currentInteraction) {
+               || interactionType !== this.currentInteraction) {
                 // console.log('Change to ', nextState.mapView.interaction, ' interaction.');
                 // "null" refers to the selection layer, "true" means only one feature
                 //   at a time.

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -26,7 +26,7 @@ import React from 'react';
 import { Provider, connect } from 'react-redux';
 
 import { removeQuery, changeTool, zoomToExtent } from '../actions/map';
-import { finishService } from '../actions/service';
+import { startService, finishService } from '../actions/service';
 import * as mapActions from '../actions/map';
 import { clearFeatures } from '../actions/mapSource';
 import { setUiHint } from '../actions/ui';
@@ -319,15 +319,18 @@ class ServiceManager extends React.Component {
             const serviceDef = this.props.services[serviceName];
             if (
                 serviceDef &&
-                serviceDef.autoGo === true &&
                 this.props.selectionFeatures !== prevProps.selectionFeatures &&
                 this.props.selectionFeatures.length > 0
             ) {
-                this.props.startQuery(
-                    this.props.selectionFeatures,
-                    this.props.services[serviceName],
-                    this.state.values
-                );
+                if (serviceDef.autoGo === true) {
+                    this.props.startQuery(
+                        this.props.selectionFeatures,
+                        this.props.services[serviceName],
+                        this.state.values
+                    );
+                } else {
+                    this.props.startService(serviceName);
+                }
             }
         }
     }
@@ -352,7 +355,9 @@ class ServiceManager extends React.Component {
                     onSubmit={(values) => {
                         if (service_def.autoGo !== true) {
                             // end the drawing
-                            this.props.changeDrawTool(null);
+                            if (service_def.keepAlive !== true) {
+                                this.props.changeDrawTool(null);
+                            }
                             this.props.startQuery(this.props.selectionFeatures, service_def, values);
                         }
                         this.setState({values, });
@@ -458,6 +463,9 @@ function mapDispatch(dispatch, ownProps) {
         },
         setUiHint: hint => {
             dispatch(setUiHint(hint));
+        },
+        startService: serviceName => {
+            dispatch(startService(serviceName));
         },
     };
 }

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -73,7 +73,7 @@ function SelectService(Application, options) {
     /** keepAlive = true will keep the service in 'query mode'
      *                   in the background, until it is explictly turned off.
      */
-    this.keepAlive = false;
+    this.keepAlive = (options.keepAlive === true);
 
     /** User input fields, select allows choosing a layer */
     this.fields = options.fields || [{


### PR DESCRIPTION
 1. `keepAlive` will keep the users last draw tool active for the service.
    When the user draws a new feature then it will go back to the service-form.
    This is in contrast to `autoGo` which assumes no input from the user.
 2. The `keepAlive` property is now set to true in the demo app.
    This show cases how the user can repeatedly draw a new polygon.
    And keep changing settings.