### PR TITLE
Support a list-of-ilikes search

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -108,17 +108,22 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
         ],
         prepareFields: function (fields) {
             // this pulls out the term from the search
-            const searchTerm = fields[0].value;
+            const searchTerms = fields[0].value.split(' ');
             // this is the list of fields in the layer which will be searched.
             const searchFields = ['OWNER_NAME', 'OWN_ADD_L1', 'OWN_ADD_L2'];
             // this switched to matching any field
             var query = ['or'];
-            for(var i = 0, ii = searchFields.length; i < ii; i++) {
-                query.push({
-                    comparitor: 'ilike',
-                    name: searchFields[i],
-                    value: '%' + searchTerm + '%'
-                });
+            for (var i = 0, ii = searchFields.length; i < ii; i++) {
+                const subquery = ['and'];
+                for (var v = 0, vv = searchTerms.length; v < vv; v++) {
+                    const searchTerm = searchTerms[v];
+                    subquery.push({
+                        comparitor: 'ilike',
+                        name: searchFields[i],
+                        value: '%' + searchTerm + '%'
+                    });
+                }
+                query.push(subquery);
             }
             return [query];
         },

--- a/src/gm3/components/layers/wfs.js
+++ b/src/gm3/components/layers/wfs.js
@@ -55,9 +55,20 @@ const FILTER_MAPPING = {
     'lt': ol_filters.lessThan
 };
 
-function mapFilters(fields) {
-    return fields.map(filter => FILTER_MAPPING[filter.comparitor](filter.name, filter.value));
-}
+const FILTER_OPERATORS = {
+    'and': ol_filters.and,
+    'or': ol_filters.or,
+};
+
+const mapFilters = fields => {
+    return fields.map(field => {
+        if (Array.isArray(field)) {
+            return chainFilters(FILTER_OPERATORS[field[0]], mapFilters(field.slice(1)));
+        } else {
+            return FILTER_MAPPING[field.comparitor](field.name, field.value);
+        }
+    });
+};
 
 export function buildWfsQuery(query, mapSource, mapProjection, outputFormat) {
     const geom_field = 'geom';
@@ -70,11 +81,6 @@ export function buildWfsQuery(query, mapSource, mapProjection, outputFormat) {
         query_projection = new proj.get('EPSG:4326');
     }
 
-    const operators = {
-        'and': ol_filters.and,
-        'or': ol_filters.or,
-    };
-
     const filters = [];
     if(query.selection && query.selection.geometry) {
         // convert the geojson geometry into a ol geometry.
@@ -85,21 +91,13 @@ export function buildWfsQuery(query, mapSource, mapProjection, outputFormat) {
         filters.push(ol_filters.intersects(geom_field, ol_geom));
     }
 
-    for(const filter of query.fields) {
-        // TODO: Catch "filter.type" and use internal conversion
-        //       functions for specialty filters.
-        if (Array.isArray(filter)) {
-            filters.push(chainFilters(operators[filter[0]], mapFilters(filter.slice(1))));
-        } else {
-            filters.push(FILTER_MAPPING[filter.comparitor](filter.name, filter.value));
-        }
-    }
+    mapFilters(query.fields).forEach(f => filters.push(f));
 
     // when multiple filters are set then they need to be
     //  chained together to create the compound filter.
     let chained_filters = null;
     if(filters.length > 1) {
-        chained_filters = chainFilters(operators.and, filters);
+        chained_filters = chainFilters(FILTER_OPERATORS.and, filters);
     } else {
         chained_filters = filters[0];
     }


### PR DESCRIPTION
This builds on the single-search terms search.
It can search multiple fields and the order of terms won't matter.

For example "terry little" and "little terry" will now return the
same list.