### PR TITLE
Add scale-based smarts to WMS legends

### DIFF
--- a/src/gm3/components/catalog/legend.js
+++ b/src/gm3/components/catalog/legend.js
@@ -43,7 +43,11 @@ class CatalogLegend extends Component {
     }
 
     renderLegend(src) {
-        const legend = getLegend(this.props.mapSources[src.mapSourceName], this.props.mapView, src.layerName);
+        const legend = getLegend(
+            this.props.mapSources[src.mapSourceName],
+            this.props.mapView,
+            src.layerName
+        );
 
         const key = 'legend_' + src.mapSourceName + '_' + src.layerName;
         let legend_idx = 0;

--- a/src/gm3/components/layers/wms.js
+++ b/src/gm3/components/layers/wms.js
@@ -29,6 +29,9 @@
 import * as util from '../../util';
 import Image from 'ol/layer/Image';
 import ImageWMS from 'ol/source/ImageWMS';
+import * as proj from 'ol/proj';
+
+const WEBMERC_PROJ = proj.get('EPSG:3857');
 
 /** Create the parameters for a WMS layer.
  *
@@ -109,7 +112,7 @@ export function getLegend(mapSource, mapView, layerName) {
 
     const params = Object.assign({
         'REQUEST': 'GetLegendGraphic',
-        // 'SCALE': TODO: get a scale hint from the map.
+        'SCALE': util.getScale(mapView.resolution, WEBMERC_PROJ),
         'SERVICE': 'WMS',
         // TODO: Does this need to be passed in? Check by server-type?
         'VERSION': '1.1.1',

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -777,3 +777,19 @@ export function getExtentForQuery(results, minSize = 150) {
 
     return extent;
 }
+
+/**
+ * Calculate the scale based on the projection and resolution.
+ * Very much inspired by ol/source/ImageWMS
+ *
+ * @params resolution - Resolution from the map
+ * @params projection - Map projection
+ *
+ * @returns Number. The scale.
+ */
+export function getScale(resolution, projection) {
+    const mpu = projection ? projection.getMetersPerUnit() : 1;
+    const dpi = 25.4 / 0.28;
+    const inchesPerMeter = 39.37;
+    return resolution * mpu * inchesPerMeter * dpi;
+}

--- a/tests/gm3/components/layers/wms.test.js
+++ b/tests/gm3/components/layers/wms.test.js
@@ -35,7 +35,11 @@ describe('WMS Layer Tests', function() {
             params: {},
         };
 
-        const legend_def = WmsLayer.getLegend(mapSource, null, 'test');
+        const mapView = {
+            resolution: 30,
+        };
+
+        const legend_def = WmsLayer.getLegend(mapSource, mapView, 'test');
 
         expect(legend_def.images[0].indexOf('??')).toBeLessThan(0);
     });


### PR DESCRIPTION
1. Adds new scale calculation function (heavily lifted from the OL code base).
2. Adds `SCALE` parameter to WMS GetLegendGraphic requests.