### PR TITLE
Fix translation of drawing tools.

### DIFF
--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -947,12 +947,7 @@ class Map extends React.Component {
      */
     createStopTool(type) {
         // "translate" a description of the tool
-        let tool_desc = this.props.t({
-            Polygon: 'end-drawing',
-            LineString: 'end-drawing',
-            Point: 'end-drawing',
-            Select: 'end-selection',
-        }[type]);
+        let tool_desc = this.props.t(type === 'Select' ? 'end-select' : 'end-drawing');
 
         // helpful default behaviour for when the description
         //  is not defined.


### PR DESCRIPTION
The dictionary was incomplete. This simplifys the logic.

refs: #495