### PR TITLE
Fix for service startup and hash tracking issue

### DIFF
--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -685,22 +685,26 @@ class Application {
      */
     startService(serviceName, options) {
         this.store.dispatch(serviceActions.startService(serviceName));
-        if (options) {
-            if (options.changeTool) {
-                this.store.dispatch(mapActions.changeTool(options.changeTool));
-            }
-            if (options.withFeatures) {
-                // reset the buffer when adding features.
-                this.store.dispatch(mapActions.setSelectionBuffer(0));
-                // dispatch the features
-                this.store.dispatch(mapActions.clearSelectionFeatures());
-                options.withFeatures.forEach(feature => {
-                    this.store.dispatch(mapActions.addSelectionFeature(feature));
-                });
-                this.store.dispatch(mapSourceActions.clearFeatures('selection'));
-                this.store.dispatch(mapSourceActions.addFeatures('selection', options.withFeatures));
-            }
+
+        const nextTool = (options && options.changeTool)
+            ? options.changeTool
+            : this.services[serviceName].tools.default;
+
+        this.store.dispatch(mapActions.changeTool(nextTool));
+
+        if (options && options.withFeatures) {
+            // reset the buffer when adding features.
+            this.store.dispatch(mapActions.setSelectionBuffer(0));
+            // dispatch the features
+            this.store.dispatch(mapActions.clearSelectionFeatures());
+            options.withFeatures.forEach(feature => {
+                this.store.dispatch(mapActions.addSelectionFeature(feature));
+            });
+            this.store.dispatch(mapSourceActions.clearFeatures('selection'));
+            this.store.dispatch(mapSourceActions.addFeatures('selection', options.withFeatures));
         }
+
+        this.store.dispatch(uiActions.setUiHint('service-start'));
     }
 
     /** Handle updating the UI, does nothing in vanilla form.

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -1223,7 +1223,8 @@ class Map extends React.Component {
                 this.map.getView().setResolution(view.resolution);
             }
 
-            if(map_view.getZoom() !== view.zoom) {
+            // ensure zoom is defined.
+            if (view.zoom && map_view.getZoom() !== view.zoom) {
                 this.map.getView().setZoom(view.zoom);
             }
         }


### PR DESCRIPTION
1. Padding in an undefined or null zoom was causing issues on
   restore.
2. Also fixed the bug with directly calling `startService`:
   a. The tool was not being activated.
   b. The UI hint was not being triggered to show the super tab.