### PR TITLE
Added sanity check to grid to prevent error on undefined query

### DIFF
--- a/src/gm3/components/grid.js
+++ b/src/gm3/components/grid.js
@@ -516,10 +516,10 @@ class Grid extends React.Component {
 
     componentDidUpdate(prevProps) {
         // check to see if the grid should start open minimized.
-        if (prevProps.queries.order[0] !== this.props.queries.order[0]) {
+        if (prevProps.queries.order[0] !== this.props.queries.order[0] && this.props.queries.order[0]) {
             const queryId = this.props.queries.order[0];
             const query = this.props.queries[queryId];
-            if (query.runOptions && query.runOptions.gridMinimized === true) {
+            if (query && query.runOptions && query.runOptions.gridMinimized === true) {
                 this.setState({minimized: true});
             }
         }


### PR DESCRIPTION
If the previous query was cleared with no replacement
the grid would throw an error since the query was undefined.

refs: #501