### PR TITLE
Improvement to service-life-cycle and tools

### DIFF
--- a/src/gm3/actionTypes.js
+++ b/src/gm3/actionTypes.js
@@ -107,9 +107,9 @@ export const QUERY = {
 
 export const SERVICE = {
     START: 'SERVICE_START',
-    FINISH: 'SERVICE_FINISH'
+    FINISH: 'SERVICE_FINISH',
+    SHOW_FORM: 'SERVICE_SHOW_FORM',
 };
-
 
 export const UI = {
     HINT: 'UI_HINT',

--- a/src/gm3/actions/service.js
+++ b/src/gm3/actions/service.js
@@ -36,3 +36,10 @@ export function startService(serviceName) {
         service: serviceName
     }
 }
+
+export function showServiceForm(show) {
+    return {
+        type: SERVICE.SHOW_FORM,
+        show,
+    };
+}

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -946,11 +946,11 @@ class Map extends React.Component {
     createStopTool(type) {
         // "translate" a description of the tool
         let tool_desc = this.props.t(type === 'Select' ? 'end-select' : 'end-drawing');
-
-        // helpful default behaviour for when the description
-        //  is not defined.
-        if(typeof(tool_desc) === 'undefined') {
-            tool_desc = this.props.t('finish') + ' ' + type;
+        if (this.props.serviceName
+            && this.props.services[this.props.serviceName]
+        ) {
+            const title = this.props.services[this.props.serviceName].title;
+            tool_desc = this.props.t('end') + ' ' + this.props.t(title);
         }
 
         // yikes this is super not-reacty.
@@ -960,6 +960,9 @@ class Map extends React.Component {
         // when the button is clicked, stop drawing.
         button.onclick = () => {
             this.props.store.dispatch(mapActions.changeTool(null));
+
+            if (this.props.serviceName) {
+            }
         };
 
         // create a wrapper div that places the button in the map
@@ -1333,6 +1336,7 @@ function mapState(state) {
         mapSources: state.mapSources,
         mapView: state.map,
         queries: state.query,
+        serviceName: state.query.service,
         config: state.config.map || {},
         selectionStyle: state.config.selectionStyle || {},
         // resolve this to meters

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -1331,6 +1331,10 @@ class Map extends React.Component {
     }
 }
 
+Map.defaultProps = {
+    services: {},
+};
+
 function mapState(state) {
     return {
         mapSources: state.mapSources,

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -27,7 +27,7 @@ import { Provider, connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 
 import { removeQuery, changeTool, zoomToExtent } from '../actions/map';
-import { startService, finishService } from '../actions/service';
+import { startService, finishService, showServiceForm } from '../actions/service';
 import * as mapActions from '../actions/map';
 import { clearFeatures } from '../actions/mapSource';
 import { setUiHint } from '../actions/ui';
@@ -181,10 +181,6 @@ class ServiceManager extends React.Component {
         );
     }
 
-    closeForm() {
-        this.props.store.dispatch(finishService());
-    }
-
     /** Iterate through all of the queries and execute
      *  the service's 'runQuery' method if the query is
      *  in the appropriate state.
@@ -260,7 +256,7 @@ class ServiceManager extends React.Component {
         const code = evt.which;
         if(code === 13) {
         } else if(code === 27) {
-            this.closeForm();
+            this.props.onServiceFinished();
         }
     }
 
@@ -315,7 +311,7 @@ class ServiceManager extends React.Component {
             //  object constructed above into a useful set of 'props'
             //  for measure tool.
             contents = ( <MeasureTool {...m_tool_props} /> );
-        } else if(this.props.queries.service != null) {
+        } else if(this.props.queries.service !== null && this.props.queries.showServiceForm) {
             const service_name = this.props.queries.service;
             const service_def = this.props.services[service_name];
 
@@ -409,9 +405,10 @@ function mapDispatch(dispatch, ownProps) {
             if(serviceDef.keepAlive !== true) {
                 // shutdown the drawing on the layer.
                 dispatch(changeTool(null));
+                dispatch(finishService());
+            } else {
+                dispatch(showServiceForm(false));
             }
-
-            dispatch(finishService());
 
             ownProps.services[serviceDef.name].query(selection, fields);
         },
@@ -432,6 +429,7 @@ function mapDispatch(dispatch, ownProps) {
             dispatch(clearFeatures('selection'));
         },
         onServiceFinished: () => {
+            dispatch(changeTool(null));
             dispatch(finishService());
         },
         setUiHint: hint => {
@@ -439,6 +437,9 @@ function mapDispatch(dispatch, ownProps) {
         },
         startService: serviceName => {
             dispatch(startService(serviceName));
+        },
+        showServiceForm: show => {
+            dispatch(showServiceForm(show));
         },
     };
 }

--- a/src/gm3/components/toolbar/button.js
+++ b/src/gm3/components/toolbar/button.js
@@ -74,15 +74,20 @@ function mapDispatch(dispatch, ownProps) {
             if(tool.actionType === 'service') {
                 // start the service
                 dispatch(startService(tool.name));
+                let defaultTool = null;
+                if (ownProps.serviceDef
+                    && ownProps.serviceDef.tools
+                    && ownProps.serviceDef.tools.default
+                ) {
+                    defaultTool = ownProps.serviceDef.tools.default;
+                }
+
                 // reset the buffer if changing tools
                 if (tool.name !== currentService) {
                     dispatch(setSelectionBuffer(0));
-                }
-                if (ownProps.serviceDef && ownProps.serviceDef.tools && ownProps.serviceDef.tools.default) {
-                    // switch to the default tool if the current tool is null or not supported.
-                    if (currentDrawTool === null || !ownProps.serviceDef.tools[currentDrawTool]) {
-                        dispatch(changeTool(ownProps.serviceDef.tools.default));
-                    }
+                    dispatch(changeTool(defaultTool));
+                } else if (currentDrawTool === null) {
+                    dispatch(changeTool(defaultTool));
                 }
                 // give an indication that a new service has been started
                 dispatch(setUiHint('service-start'));

--- a/src/gm3/components/toolbar/drawer.js
+++ b/src/gm3/components/toolbar/drawer.js
@@ -32,7 +32,7 @@ import PropTypes from 'prop-types';
 import ToolbarButton from './button';
 import { useTranslation } from 'react-i18next';
 
-const ToolbarDrawer = ({label, tools}) => {
+const ToolbarDrawer = ({label, tools, services}) => {
     const {t} = useTranslation();
     return (
         <div className='drawer tool'>
@@ -44,6 +44,9 @@ const ToolbarDrawer = ({label, tools}) => {
                             <ToolbarButton
                                 key={`btn${i}`}
                                 tool={tool}
+                                serviceDef={
+                                    tool.actionType === 'service' ? services[tool.name] : undefined
+                                }
                             />
                         );
                     })

--- a/src/gm3/components/toolbar/index.js
+++ b/src/gm3/components/toolbar/index.js
@@ -45,6 +45,7 @@ export class Toolbar extends React.Component {
                                         key={ tool.name }
                                         label={ tool.label }
                                         tools={ this.props.toolbar[tool.name] }
+                                        services={ this.props.services }
                                     />
                                 );
                             } else {

--- a/src/gm3/lang/en.json
+++ b/src/gm3/lang/en.json
@@ -33,6 +33,7 @@
   "draw-polygon-tip" : "Add a Polygon to the layer",
   "draw-remove-tip" : "Remove a feature from the layer",
   "draw-select-label" : "Feature from:",
+  "end" : "End",
   "end-drawing" : "End Drawing",
   "end-select" : "End Selection",
   "fade-tip" : "Fade layer",

--- a/src/gm3/lang/es.json
+++ b/src/gm3/lang/es.json
@@ -32,6 +32,7 @@
   "draw-polygon-tip" : "Añadir objeto poligonal",
   "draw-remove-tip" : "Eliminar objetos de la capa",
   "draw-select-label" : "Objetos de:",
+  "end" : "Terminar de",
   "end-drawing" : "Terminar de dibujar",
   "end-select" : "Terminar de seleccionar",
   "fade-tip" : "Oscurecer capa",

--- a/src/gm3/reducers/query.js
+++ b/src/gm3/reducers/query.js
@@ -101,9 +101,9 @@ export default function queryReducer(state = default_query, action) {
     const new_query = {};
     switch(action.type) {
         case SERVICE.START:
-            return Object.assign({}, state, {service: action.service});
+            return Object.assign({}, state, {service: action.service, showServiceForm: true});
         case SERVICE.FINISH:
-            return Object.assign({}, state, {service: null});
+            return Object.assign({}, state, {serivce: null, showServiceForm: false});
         case MAP.QUERY_NEW:
             const query_id = uuid.v4();
             new_query[query_id] = Object.assign({}, action.query, {
@@ -178,6 +178,11 @@ export default function queryReducer(state = default_query, action) {
                 filter: new_filter
             });
             return Object.assign({}, state, new_query);
+        case SERVICE.SHOW_FORM:
+            return Object.assign({},
+                state,
+                {showServiceForm: action.show}
+            );
         default:
             return state;
     }

--- a/tests/gm3/components/toolbar.test.js
+++ b/tests/gm3/components/toolbar.test.js
@@ -64,7 +64,7 @@ describe('Toolbar component tests', () => {
             actionType: 'service', actionDetail: 'sample'
         };
 
-        shallow(<ToolbarDrawer label='Drawer Zero' tools={[tool]} />);
+        shallow(<ToolbarDrawer label='Drawer Zero' tools={[tool]} services={{}} />);
     });
 
     it('renders a toolbar', () => {
@@ -89,7 +89,7 @@ describe('Toolbar component tests', () => {
             map: mapReducer,
         }));
 
-        shallow(<Toolbar store={store} toolbar={toolbar} />);
+        shallow(<Toolbar store={store} toolbar={toolbar} services={{}} />);
     });
 
     it('renders a toolbar from the store', function() {
@@ -106,7 +106,7 @@ describe('Toolbar component tests', () => {
             actionType: 'service', actionDetail: 'sample2'
         }));
 
-        mount(<SmartToolbar store={store}/>);
+        mount(<SmartToolbar store={store} services={{}} />);
     });
 
     it('renders a toolbar from a mapbook fragment', function() {


### PR DESCRIPTION
1. When a tool is "Restarted" it returns the form and
   settings from before.
2. When switching tools the defualt tool is always selected.
3. The "stop tool" on the map now uses the service name as available.