### PR TITLE
Fix for Select input when the default is missing

### DIFF
--- a/src/gm3/components/serviceInputs/select.js
+++ b/src/gm3/components/serviceInputs/select.js
@@ -35,9 +35,12 @@ export default class SelectInput extends TextInput {
         return this.props.field.options;
     }
 
-    componentWillMount() {
+    componentDidMount() {
         const options = this.getOptions();
-        if(typeof this.props.field.default === 'undefined') {
+        if (
+            this.props.field.default === undefined ||
+            options.filter(v => v.value === this.props.field.default).length < 1
+        ) {
             this.onChange({target: {value: options[0].value}});
         }
     }


### PR DESCRIPTION
There was an issue with the Selects not properly updating
their value when the default was missing.

refs: #514 