### PR TITLE
Fix for service return not going to results tab

### DIFF
--- a/examples/mobile/mobile.js
+++ b/examples/mobile/mobile.js
@@ -53,7 +53,7 @@ function changeTab(tabName) {
 app.uiUpdate = function(ui) {
     // when the UI hint is set for the service manager
     //  show the service manager tab.
-    if(ui.hint == 'service-manager') {
+    if (ui.hint === 'new-results') {
         changeTab('service-tab');
         app.clearHint();
     }

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -300,6 +300,13 @@ class ServiceManager extends React.Component {
                 }
             }
         }
+
+        if (!this.props.queries.showServiceForm &&
+            this.props.queries.order.length > 0 &&
+            prevProps.queries.order[0] !== this.props.queries.order[0]
+        ) {
+            this.props.setUiHint('new-results');
+        }
     }
 
     render() {


### PR DESCRIPTION
1. Added new hint to indicate new results.
2. Fixed mobile to use that new hint.

refs: #519