### PR TITLE
fixes for WFS and AGS server requests

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -69,6 +69,31 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     });
 
     app.registerService('identify', IdentifyService);
+
+    app.registerService('search-runways', SearchService, {
+        fields: [
+            {type: 'text', label: 'Name', name: 'Name'},
+        ],
+        searchLayers: ['ags-vector-dc21/runways'],
+        validateFieldValues: function (fields) {
+            let nonEmpty = 0;
+            const validateFieldValuesResult = {
+                valid: true,
+                message: null
+            };
+
+            if (fields['Name'] !== undefined && fields['Name'] !== '') {
+                    nonEmpty++;
+            }
+
+            if (nonEmpty === 0) {
+                validateFieldValuesResult.valid = false;
+                validateFieldValuesResult.message = 'Please complete at least one field.'
+            }
+            return validateFieldValuesResult;
+        }
+    });
+
     app.registerService('search', SearchService, {
         fields: [
             {type: 'text', label: 'Owner Name', name: 'OWNER_NAME'},

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -248,7 +248,64 @@
                 </td>
             </tr>
             ]]></template>
+            <template name="identify" auto="true" />
+        </layer>
+    </map-source>
 
+    <map-source name="ags-vector-dc21" type="ags-vector">
+        <url>https://gis2.co.dakota.mn.us/arcgis/rest/services/DCGIS_OL_Transportation/MapServer/21</url>
+        <layer name="runways" selectable="true" title="Runways">
+            <style><![CDATA[
+            {
+                "line-color" : "#010138",
+                "line-width" : 2
+            }
+            ]]></style>
+            <template name="identify" auto="true" />
+            <template name="search"><![CDATA[
+                <div class="search-result">
+                    <div class="search-label">
+                        {{ properties.Name }}
+                    </div>
+                    <div class="search-action">
+                        <div style="padding: 2px">
+                            <a onClick="app.zoomToExtent([{{ properties.boundedBy | join }}], 'EPSG:3857')" class="zoomto-link">
+                                <i class="fa fa-search"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            ]]></template>
+            <template name="select" alias="search"/>
+            <template name="gridColumns"><![CDATA[
+            [
+                {
+                    "title": ""
+                },
+                {
+                    "title": "Name",
+                    "property" : "Name",
+                    "filter" : {
+                        "type" : "list"
+                    }
+                }
+            ]
+            ]]></template>
+            <template name="gridRow"><![CDATA[
+            <tr
+              onmouseenter="app.highlightFeatures({'OBJECTID' : '{{ properties.OBJECTID }}'}, true)"
+              onmouseleave="app.clearHighlight()"
+            >
+                <td>
+                  <a onClick="app.zoomToExtent([{{ properties.boundedBy | join }}], 'EPSG:3857')" class="zoomto-link">
+                    <i class="fa fa-search"></i>
+                  </a>
+                </td>
+                <td>
+                  {{ properties.Name }}
+                </td>
+            </tr>
+            ]]></template>
         </layer>
     </map-source>
 
@@ -405,6 +462,7 @@
                 <layer title="City and County Boundaries" src="borders/county_borders;borders/city_poly"/>
                 <layer title="AGS Dakota County Rail" src="ags-vector-dc16/railroads"/>
                 <!--layer title="AGS Dakota County Streets" src="ags-vector-dc20/roads"/-->
+                <layer title="AGS Dakota County Runways" src="ags-vector-dc21/runways"></layer>
             </group>
             <layer src="pipelines/pipelines"></layer>
             <layer title="Weather Radar" src="iastate/nexrad-n0r" />
@@ -450,6 +508,7 @@
         <tool name="select" title="Select Features" type="service"/>
 
         <drawer name="searches" title="Search">
+            <tool name="search-runways" title="Search Runways" type="service"/>
             <tool name="search" title="Search Parcels" type="service"/>
             <tool name="single-search" css-class="tool search" title="Single field search" type="service"/>
             <tool name="geocode" title="Geocode an Address" type="service"/>

--- a/src/gm3/components/layers/vector.js
+++ b/src/gm3/components/layers/vector.js
@@ -77,14 +77,14 @@ function defineSource(mapSource) {
                     console.error('No "typename" param defined for a WFS layer. This will fail.');
                 }
 
-                const url_params = Object.assign({}, mapSource.params, {
+                const url_params = Object.assign({}, {
                     'srsname': 'EPSG:3857',
                     'outputFormat': output_format,
                     'service': 'WFS',
                     'version': '1.1.0',
                     'request': 'GetFeature',
                     'bbox': extent.concat('EPSG:3857').join(',')
-                });
+                }, mapSource.params);
 
                 return mapSource.urls[0] + '?' + formatUrlParameters(url_params);
             },

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -471,6 +471,19 @@ class Map extends React.Component {
 
         if (query.selection.length > 0) {
             const queryGeometry = query.selection[0].geometry;
+            // Since AGS servers don't "intersect" a point with anything, we make a box
+            // Make a 4 pixel (2 pixels each way) box around the point
+            if (queryGeometry.type === 'Point'){
+                const res = this.map.getView().getResolution() * 2;
+                const pt = queryGeometry.coordinates;
+                queryGeometry.type = 'Polygon'
+                queryGeometry.coordinates = [[
+                    [pt[0] + res, pt[1] + res],
+                    [pt[0] + res, pt[1] - res],
+                    [pt[0] - res, pt[1] - res],
+                    [pt[0] - res, pt[1] + res]
+                ]]
+            }
             // make this an E**I geometry.
             const ol_geom = GEOJSON_FORMAT.readGeometry(queryGeometry);
 

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -435,10 +435,10 @@ class Map extends React.Component {
         //  types
         const filter_mapping = {
             'like': function(name, value) {
-                return name + ' like ' + fix_like(value);
+                return name + " like '" + fix_like(value) + "'";
             },
             'ilike': function(name, value) {
-                return name + ' like upper(' + fix_like + ')'
+                return "upper(" + name + ") like upper('" + fix_like(value) + "')";
             },
             'eq': function(name, value) {
                 return simple_op('=', name, value);
@@ -485,7 +485,7 @@ class Map extends React.Component {
             // setup the spatial filter.
             query_params.geometryType = geom_type_lookup[queryGeometry.type];
             query_params.geometry = esri_format.writeGeometry(ol_geom);
-            query_params.spatialRel = 'esriSpatialRelIntersects';
+            query_params.spatialRel = 'esriSpatialRelIntersects'; // for lines?:'esriSpatialRelEnvelopeIntersects';
         }
 
         // build the filter fields.
@@ -494,12 +494,7 @@ class Map extends React.Component {
             where_statements.push(filter_mapping[filter.comparitor](filter.name, filter.value));
         }
 
-        const where_str = where_statements.join(' and ');
-
-        query_params.layers = JSON.stringify([{
-            layerId: layer_name,
-            'where': where_str,
-        }]);
+        query_params.where = where_statements.join(' and ');
 
         // get the query service url.
         const query_url = map_source.urls[0] + '/query/';
@@ -512,28 +507,36 @@ class Map extends React.Component {
                 // not all WMS services play nice and will return the
                 //  error message as a 200, so this still needs checked.
                 if(response) {
-                    // convert the esri features to OL features.
-                    const features = esri_format.readFeatures(response);
-                    // be ready with some json.
-                    const json_format = new GeoJSONFormat();
+                    if (response.error && response.error.code != 200){
+                        console.error(response.error);
+                        this.props.store.dispatch(
+                            // true for 'failed', empty array to prevent looping side-effects.
+                            mapActions.resultsForQuery(queryId, queryLayer, true, [])
+                        );
+                    } else {
+                        // convert the esri features to OL features.
+                        const features = esri_format.readFeatures(response);
+                        // be ready with some json.
+                        const json_format = new GeoJSONFormat();
 
-                    // create the features array.
-                    let js_features = [];
-                    for(const feature of features) {
-                        // feature to JSON.
-                        const js_feature = json_format.writeFeatureObject(feature);
-                        // ensure that every feature has a "boundedBy" attribute.
-                        js_feature.properties.boundedBy = feature.getGeometry().getExtent();
-                        // add it to the stack.
-                        js_features.push(js_feature);
+                        // create the features array.
+                        let js_features = [];
+                        for(const feature of features) {
+                            // feature to JSON.
+                            const js_feature = json_format.writeFeatureObject(feature);
+                            // ensure that every feature has a "boundedBy" attribute.
+                            js_feature.properties.boundedBy = feature.getGeometry().getExtent();
+                            // add it to the stack.
+                            js_features.push(js_feature);
+                        }
+
+                        // apply the transforms
+                        js_features = util.transformFeatures(map_source.transforms, js_features);
+
+                        this.props.store.dispatch(
+                            mapActions.resultsForQuery(queryId, queryLayer, false, js_features)
+                        );
                     }
-
-                    // apply the transforms
-                    js_features = util.transformFeatures(map_source.transforms, js_features);
-
-                    this.props.store.dispatch(
-                        mapActions.resultsForQuery(queryId, queryLayer, false, js_features)
-                    );
                 }
             },
             error: () => {


### PR DESCRIPTION
The change in vector.js allows the user supplied params in a WFS map-source to over-ride the default GM params (unfortunately the param names are case-sensitive).


 

