### PR TITLE
Add Legend Printing

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -225,7 +225,7 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     var print_preview = app.add(gm3.components.PrintModal, 'print-preview', {});
     app.registerAction('print', function() {
         this.run = function() {
-           print_preview.setState({open: true});
+            app.showModal('print');
         }
     }, {});
 

--- a/src/gm3/actionTypes.js
+++ b/src/gm3/actionTypes.js
@@ -115,7 +115,8 @@ export const UI = {
     HINT: 'UI_HINT',
     CLEAR_HINT: 'UI_CLEAR_HINT',
     RUN_ACTION: 'UI_RUN_ACTION',
-    CLEAR_ACTION: 'UI_CLEAR_ACTION'
+    CLEAR_ACTION: 'UI_CLEAR_ACTION',
+    SHOW_MODAL: 'UI_SHOW_MODAL',
 };
 
 export const PRINT = {

--- a/src/gm3/actions/ui.js
+++ b/src/gm3/actions/ui.js
@@ -47,3 +47,17 @@ export function clearAction() {
         type: UI.CLEAR_ACTION
     };
 }
+
+export function showModal(modalKey) {
+    return {
+        type: UI.SHOW_MODAL,
+        payload: modalKey,
+    };
+}
+
+export function hideModal() {
+    return {
+        type: UI.SHOW_MODAL,
+        payload: '',
+    };
+}

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -755,6 +755,10 @@ class Application {
         ReactDOM.render(e, modal_div);
     }
 
+    showModal(modalKey) {
+        this.store.dispatch(uiActions.showModal(modalKey));
+    }
+
     /* Set the view of the map
      *
      * @param view {Object} A view definition containing center and zoom or resolution

--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -1382,7 +1382,7 @@ export default connect(mapState, mapDispatch)(withTranslation()(Map));
 export function getLegend(mapSource, mapView, layerName) {
     // see if the layer has a fixed legend.
     for(const layer of mapSource.layers) {
-        if(layer.name === layerName && layer.legend !== null) {
+        if(layer.name === layerName && layer.legend !== undefined && layer.legend !== null) {
             // translate from the store represenation to
             // what's used to render the legend.
             if(layer.legend.type === 'html') {

--- a/src/gm3/components/print/printLayouts.js
+++ b/src/gm3/components/print/printLayouts.js
@@ -28,6 +28,50 @@
 
 const LAYOUTS = [
     {
+        label: 'letter-landscape-legend',
+        orientation: 'landscape',
+        page: 'letter',
+        units: 'in',
+        elements: [
+            {
+                type: 'text',
+                size: 18, fontStyle: 'bold',
+                x: .5, y: .70, text: '{{title}}'
+            },
+            {
+                type: 'map',
+                x: .5, y: .75,
+                width: 7, height: 7
+            },
+            {
+                type: 'rect',
+                x: .5, y: .75,
+                width: 7, height: 7,
+                strokeWidth: .01
+            },
+            {
+                type: 'text',
+                x: .5, y: 8, text: 'Printed on {{month}} / {{day}} / {{year}}'
+            },
+            {
+                type: 'text',
+                x: 7.6, y: .9,
+                text: 'Legend',
+            },
+            {
+                type: 'legend',
+                x: 7.61, y: 1.0
+            },
+            {
+                type: 'rect',
+                x: 7.6, y: .75,
+                width: 2.4,
+                height: 7,
+                strokeWidth: .01,
+            }
+        ]
+    },
+    {
         label: 'letter-landscape',
         orientation: 'landscape',
         page: 'letter',

--- a/src/gm3/lang/en.json
+++ b/src/gm3/lang/en.json
@@ -66,6 +66,7 @@
   "measure-west-abbr" : "W",
   "no-favorites" : "No layers marked as favorite",
   "page-layout" : "Page layout",
+  "page-letter-landscape-legend" : "Letter - Landscape with Legend",
   "page-letter-landscape" : "Letter - Landscape",
   "page-letter-portrait" : "Letter - Portrait",
   "page-tabloid-landscape" : "11x17 - Landscape",

--- a/src/gm3/lang/es.json
+++ b/src/gm3/lang/es.json
@@ -65,6 +65,7 @@
   "measure-west-abbr" : "O",
   "no-favorites" : "No hay capas favoritas.",
   "page-layout" : "Composición de impresión",
+  "page-letter-landscape-legend" : "Carta - Horizontal con leyenda",
   "page-letter-landscape" : "Carta - Horizontal",
   "page-letter-portrait" : "Carta - Vertical",
   "page-tabloid-landscape" : "A3 - Horizontal",

--- a/src/gm3/reducers/ui.js
+++ b/src/gm3/reducers/ui.js
@@ -32,7 +32,8 @@ import { UI } from '../actionTypes';
 const defaultState = {
     stateId: 0,
     hint: null,
-    action: null
+    action: null,
+    modal: '',
 };
 
 export default function uiReducer(state = defaultState, action) {
@@ -51,6 +52,13 @@ export default function uiReducer(state = defaultState, action) {
             return Object.assign({}, state, {stateId: uuid(), action: action.action});
         case UI.CLEAR_ACTION:
             return Object.assign({}, state, {stateId: uuid(), action: null});
+        case UI.SHOW_MODAL:
+            return Object.assign({},
+                state,
+                {
+                    modal: action.payload,
+                },
+            );
         default:
             return state;
     }


### PR DESCRIPTION
1. New print layout which demos legends.
2. Fixes issue with needing to expose `setState` of modals
   which is a react anit-pattern (new store-drive `showModal` function
   is available through Applicaiton).
3. Works out all the async business with loading the images
   and then rendering the PDF.

refs: #327