### PR TITLE
Included clickable link

### DIFF
--- a/src/gm3/components/bookmark-modal.js
+++ b/src/gm3/components/bookmark-modal.js
@@ -32,6 +32,7 @@ class BookmarkModal extends Modal {
         return (
             <div>
                 <label>This url can be copied and pasted to make a bookmark:</label>
+                <a href={'' + document.location} target = "_blank" rel="noopener noreferrer"> Map Link</a>
                 <textarea
                     style={{
                         width: '100%',


### PR DESCRIPTION
URL's can be long and larger than box they are in. A hyperlink allows users to right click and copy rather than manually copying the entire link.

Credits to @chughes-lincoln , this is just a clean up of the git history.