### PR TITLE
Work around for DuckDuckGo Privacy Essentials

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,10 @@ function setPublicPath() {
     var distPath = '/';
     for (var i = 0; i < scriptTags.length; i++) {
         var src = scriptTags[i].getAttribute('src');
-        if (src.indexOf('geomoose.js') >= 0 || src.indexOf('geomoose.min.js') >= 0) {
-            distPath = src.split('/').slice(0, -1).join('/');
+        if (src) {
+            if (src.indexOf('geomoose.js') >= 0 || src.indexOf('geomoose.min.js') >= 0) {
+                distPath = src.split('/').slice(0, -1).join('/');
+            }
         }
     }
 


### PR DESCRIPTION
The DuckDuckGo Privacy Essentials extension for Firefox and Chrome
injects anonymous script elements into the webpage.  This breaks
an assumption in index.js that all script elements have a valid
src attribute.

In the name of defensive coding and playing well with others,
this commit protects access to the src element with a null check.

However, this seems like very sketchy behavior to me on the part of
DDG PE.  It appears identical to a malicious code injection attack.
And I'm really not sure how we are supposed to reliably code for an
environment where the definition of the environment, and even our
own application code, can be changed out from under us at any time.

fixes #607