### PR TITLE
Fix missing extent limitation bug

### DIFF
--- a/src/gm3/components/map.js
+++ b/src/gm3/components/map.js
@@ -926,7 +926,7 @@ class Map extends React.Component {
         }
 
         if (this.props.config.view) {
-            const mixinKeys = ['center', 'zoom', 'maxZoom', 'minZoom'];
+            const mixinKeys = ['extent', 'center', 'zoom', 'maxZoom', 'minZoom'];
             mixinKeys.forEach(key => {
                 if (this.props.config.view[key]) {
                     view_params[key] = this.props.config.view[key];


### PR DESCRIPTION
One line, one word, one fix!

The view configuration was missing the `extent` keyword to mix-in
to the object.

refs: #609