### PR TITLE
Fix scary errors when no selectable layers are available.

### DIFF
--- a/src/gm3/components/serviceInputs/select.js
+++ b/src/gm3/components/serviceInputs/select.js
@@ -41,7 +41,11 @@ export default class SelectInput extends TextInput {
             this.props.field.default === undefined ||
             options.filter(v => v.value === this.props.field.default).length < 1
         ) {
-            this.onChange({target: {value: options[0].value}});
+            this.onChange({
+                target: {
+                    value: options.length > 0 ? options[0].value : '',
+                },
+            });
         }
     }
 

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -326,9 +326,12 @@ export function filterFeatures(features, filter, inverse = true) {
         filter_function = createFilter(['all'].concat(filter)).filter;
     }
 
-    for(const feature of features) {
-        if(inverse !== filter_function({zoom: 15}, feature)) {
-            new_features.push(feature);
+    if (features) {
+        for (let x = 0, xx = features.length; x < xx; x++) {
+            const feature = features[x];
+            if(inverse !== filter_function({zoom: 15}, feature)) {
+                new_features.push(feature);
+            }
         }
     }
 


### PR DESCRIPTION
Select boxes were making scary errors appear and freezing the application when there were no layers available.