### PR TITLE
Add "Buffer All" functionality

### DIFF
--- a/docs/howto/customize-results.rst
+++ b/docs/howto/customize-results.rst
@@ -1,0 +1,35 @@
+How-to customize result tools
+#############################
+
+GeoMoose can be configured to off the user additional
+options for results in the Super Tab.
+
+Service results configuration options
+-------------------------------------
+
+When adding a service, administrators can configure which tools
+are available to a user using the ``results`` configuration object.
+
+Here is an example adding buffer all and removing the count
+of layers:
+
+::
+
+    app.registerService('select', SelectService, {
+        // set the default layer
+        defaultLayer: 'vector-parcels/parcels',
+        keepAlive: true,
+        results: {
+            showBufferAll: true,
+            showLayerCount: false
+        }
+    });
+
+Available options
+-----------------
+
+  * ``showFeatureCount`` - Defaults to ``true``. Show the count of features.
+  * ``showLayerCount`` - Defaults to ``true``. Show the number of layers queried.
+  * ``showBufferAll`` - Defaults to ``false``. Tool to buffer all result features.
+  * ``showZoomToAll`` - Defaults to ``true``. Tool to zoom to all result features.
+

--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -37,6 +37,10 @@ var app = new gm3.Application({
             enabled: true,
             units: 'imperial'
         }
+    },
+    results: {
+        enableBufferAll: true,
+        showLayerCount: false,
     }
 });
 
@@ -178,11 +182,18 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
         // set the default layer
         defaultLayer: 'vector-parcels/parcels',
         keepAlive: true,
+        results: {
+            showBufferAll: true,
+            showLayerCount: false
+        }
     });
 
     app.registerService('buffer-select', SelectService, {
         drawToolsLabel: '',
         tools: {'buffer': true},
+        // tell the app to use the select service templates
+        //  for this services.
+        alias: 'select',
     });
 
     // This uses the OpenStreetMap Nominatim geocoder,

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -149,16 +149,22 @@ class Application {
         }
     }
 
-    registerService(serviceName, serviceClass, options) {
-        // when options are not an object, then default it to be
-        //  an object.
-        if(typeof(options) != 'object') { options = {}; }
+    registerService(serviceName, serviceClass, options = {}) {
         // "serviceClass" should be a class that can be created,
         //  the only parameter to the constructor should be the application,
         //  which it uses to tie back to the 'react' environment.
-        this.services[serviceName] = new serviceClass(this, options);
+        const service = new serviceClass(this, options);
         // set the service name to whatever it was registered as.
-        this.services[serviceName].name = serviceName;
+        service.name = serviceName;
+        // see if there is an alais for the service.
+        service.alias = options.alias || '';
+        // check for results config
+        service.resultsConfig = {
+            ...service.resultsConfig,
+            ...options.results,
+        };
+        // add it to the services object
+        this.services[serviceName] = service;
     }
 
     /** Actions are classes with a "run" method which the application

--- a/src/gm3/components/grid.js
+++ b/src/gm3/components/grid.js
@@ -536,7 +536,8 @@ class Grid extends React.Component {
         if(query_id) {
             const query = this.props.queries[query_id];
             if(query.progress === 'finished') {
-                const serviceName = query.service;
+                const service = this.props.services[query.service];
+                const serviceName = service.alias || service.name;
                 const paths = Object.keys(query.results);
                 paths.forEach(layerPath => {
                     let layer = null;

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -29,7 +29,7 @@ import { withTranslation } from 'react-i18next';
 import { removeQuery, changeTool, zoomToExtent } from '../actions/map';
 import { startService, finishService, showServiceForm } from '../actions/service';
 import * as mapActions from '../actions/map';
-import { clearFeatures } from '../actions/mapSource';
+import { addFeatures, clearFeatures } from '../actions/mapSource';
 import { setUiHint } from '../actions/ui';
 import { getExtentForQuery } from '../util';
 
@@ -62,6 +62,13 @@ function normalizeSelection(selectionFeatures) {
     }
     return selectionFeatures;
 }
+
+const DEFAULT_CONFIG = {
+    enableBufferAll: false,
+    enableZoomTo: true,
+    showLayerCount: true,
+    showFeatureCount: true,
+};
 
 class ServiceManager extends React.Component {
 
@@ -119,6 +126,14 @@ class ServiceManager extends React.Component {
 
         const service = this.props.services[query.service];
 
+        const resultsConfig = {
+            showFeatureCount: true,
+            showLayerCount: true,
+            showBufferAll: false,
+            showZoomToAll: true,
+            ...service.resultsConfig,
+        };
+
         let service_title = service.resultsTitle;
 
         // By default show the summary, unless showSummary is explicitly
@@ -141,22 +156,37 @@ class ServiceManager extends React.Component {
 
         const info_header = (
             <div className='results-info'>
-                <div className='results-info-item features-count'>
-                    <div className='label'>{this.props.t('features')}</div>
-                    <div className='value'>{ feature_count }</div>
-                </div>
-
-                <div className='results-info-item layers-count'>
-                    <div className='label'>{this.props.t('layers')}</div>
-                    <div className='value'>{ layer_count }</div>
-                </div>
-
-                <div className='results-info-item zoomto'>
-                    <div className='label'>{this.props.t('zoomto-results')}</div>
-                    <div className='value' onClick={() => { this.props.zoomToResults(query); }}>
-                        <span className='icon zoomto'></span>
+                {resultsConfig.showFeatureCount && (
+                    <div className='results-info-item features-count'>
+                        <div className='label'>{this.props.t('features')}</div>
+                        <div className='value'>{ feature_count }</div>
                     </div>
-                </div>
+                )}
+
+                {resultsConfig.showLayerCount && (
+                    <div className='results-info-item layers-count'>
+                        <div className='label'>{this.props.t('layers')}</div>
+                        <div className='value'>{ layer_count }</div>
+                    </div>
+                )}
+
+                {resultsConfig.showBufferAll && (
+                    <div className='results-info-item buffer-all'>
+                        <div className='label'>{this.props.t('buffer-all')}</div>
+                        <div className='value' onClick={() => { this.props.bufferAll(query); }}>
+                            <span className='icon buffer'></span>
+                        </div>
+                    </div>
+                )}
+
+                {resultsConfig.showZoomToAll && (
+                    <div className='results-info-item zoomto'>
+                        <div className='label'>{this.props.t('zoomto-results')}</div>
+                        <div className='value' onClick={() => { this.props.zoomToResults(query); }}>
+                            <span className='icon zoomto'></span>
+                        </div>
+                    </div>
+                )}
             </div>
         );
 
@@ -215,8 +245,6 @@ class ServiceManager extends React.Component {
             }
             // 'rotate' the current servie to the next services.
             this.setState({lastService: nextProps.queries.service, lastFeature: ''});
-            // clear out the previous selection feaures.
-            this.props.clearSelectionFeatures();
 
             // clear out the previous field values.
             if(!this.fieldValues[nextProps.queries.service]) {
@@ -393,6 +421,7 @@ const mapState = state => ({
     queries: state.query,
     map: state.map,
     selectionFeatures: state.mapSources.selection ? state.mapSources.selection.features : [],
+    config: {...DEFAULT_CONFIG, ...state.config.results},
 });
 
 function mapDispatch(dispatch, ownProps) {
@@ -447,6 +476,34 @@ function mapDispatch(dispatch, ownProps) {
         },
         showServiceForm: show => {
             dispatch(showServiceForm(show));
+        },
+        // this is a special case that will attempt
+        //  to start the buffer-select service.
+        bufferAll: query => {
+            // flatten the query results down to just a
+            //  list of features
+            let features = [];
+            for (const path in query.results) {
+                features = features.concat(query.results[path]);
+            }
+
+            if (features.length > 0) {
+                dispatch(startService('buffer-select'));
+                dispatch(mapActions.changeTool(''));
+
+                // reset the buffer since this is a new buffer set.
+                dispatch(mapActions.setSelectionBuffer(0));
+                // dispatch the features
+                dispatch(mapActions.clearSelectionFeatures());
+                features.forEach(f => {
+                    dispatch(mapActions.addSelectionFeature(f))
+                });
+                dispatch(clearFeatures('selection'));
+                dispatch(addFeatures('selection', features));
+            } else {
+                // TODO: Dispatch an error message that it
+                //       it is not possible to buffer nothing.
+            }
         },
     };
 }

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -42,7 +42,7 @@ function normalizeSelection(selectionFeatures) {
     // OpenLayers handles MultiPoint geometries in an awkward way,
     // each feature is a 'MultiPoint' type but only contains one feature,
     //  this normalizes that in order to be submitted properly to query services.
-    if(selectionFeatures.length > 0) {
+    if(selectionFeatures && selectionFeatures.length > 0) {
         if(selectionFeatures[0].geometry.type === 'MultiPoint') {
             const all_coords = [];
             for(const feature of selectionFeatures) {

--- a/src/gm3/lang/en.json
+++ b/src/gm3/lang/en.json
@@ -12,6 +12,7 @@
   "Select Features" : "Select Features",
   "Start Over" : "Start Over",
   "Zoom to Full Extent" : "Zoom to Full Extent",
+  "buffer-all": "Buffer results",
   "cancel" : "Cancel",
   "clear-features" : "Clear Features",
   "clear-features-tip" : "Clear all features from the layer.",

--- a/src/gm3/lang/es.json
+++ b/src/gm3/lang/es.json
@@ -12,6 +12,7 @@
   "Select Features" : "Seleccionar objetos",
   "Start Over" : "Restablecer",
   "Zoom to Full Extent" : "Zoom a la extension",
+  "buffer-all": "Buffer objetos",
   "cancel" : "Cancelar",
   "clear-features" : "Limpiar objetos",
   "clear-features-tip" : "Limpiar objetos de la capa",

--- a/src/gm3/lang/fr.json
+++ b/src/gm3/lang/fr.json
@@ -12,6 +12,7 @@
   "Select Features" : "Sélectionner",
   "Start Over" : "Recharger la carte",
   "Zoom to Full Extent" : "Zoomer sur l'étendue complète",
+  "buffer-all": "Tout tamponner",
   "cancel" : "Annuler",
   "clear-features" : "Effacer les dessins",
   "clear-features-tip" : "Effacer les dessins de la couche.",

--- a/src/gm3/lang/it.json
+++ b/src/gm3/lang/it.json
@@ -11,6 +11,7 @@
   "Select Features" : "Seleziona oggetti",
   "Start Over" : "Ricarica la mappa",
   "Zoom to Full Extent" : "Zoom Estensione Massima",
+  "buffer-all": "Tampone oggetti",
   "cancel" : "Cancella",
   "clear-features" : "Pulisci oggetti",
   "clear-features-tip" : "Pulisci tutti gli oggetti dal layer.",

--- a/src/gm3/lang/pt-br.json
+++ b/src/gm3/lang/pt-br.json
@@ -12,13 +12,14 @@
     "Select Features" : "Selecionar Feições",
     "Start Over" : "Reiniciar",
     "Zoom to Full Extent" : "Enquadrar toda extensão",
+    "buffer-all": "Buffer Feições",
     "cancel" : "Cancelar",
     "clear-features" : "Limpar Feições",
     "clear-features-tip" : "Limpar todas as feições da camada.",
     "clear-previous-selection" : "Limpar a seleção anterior",
     "download-features" : "Baixar as feições",
     "download-features-tip" : "Baixar as feições para arquivo.",
-    "download-format": "Formato do download",  
+    "download-format": "Formato do download",
     "download-help" : "Escolha o formato, então clique 'Ok' para download das feições da camada no formato definido",
     "draw-box-label" : "Desenhar retângulo",
     "draw-edit-tip" : "Editar propriedades da feição",
@@ -107,4 +108,4 @@
     "zoomto-results" : "Zoom para resultados",
     "zoomto-tip" : "Zoom para toda a camada."
   }
-  
+

--- a/src/less/results.less
+++ b/src/less/results.less
@@ -105,7 +105,7 @@
                 height: 2em;
                 font-size: 2em;
 
-                .zoomto {
+                .icon {
                     font-size: 1em;
                     margin-right: 0;
                 }

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Dan "Ducky" Little
+ * Copyright (c) 2016-2021 Dan "Ducky" Little
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -167,48 +167,6 @@ function SearchService(Application, options) {
         // return the html for rendering.
         return html;
     }
-
-    /** hasRendered is an object which tells renderQueryResults to ignore
-     *              queries which have already been rendered.
-     */
-    this.hasRendered = {};
-
-    /** renderQueryResults is the function called to let the service
-     *                     run basically any code it needs to execute after
-     *                     the query has been set to finish.
-     *
-     *  WARNING! This will be called multiple times. It is best to ensure
-     *           there is some sort of flag to prevent multiple renderings.
-     */
-    this.renderQueryResults = function(queryId, query) {
-        // This is an ugly short circuit.
-        if(this.hasRendered[queryId]) {
-            // do nothing.
-            return;
-        }
-        // flag the query as rendered even though code below
-        //  this line has not finished, this prevents an accidental
-        //  double-rendering.
-        this.hasRendered[queryId] = true;
-
-        // render a set of features on a layer.
-        var all_features = [];
-        for(var i = 0, ii = query.layers.length; i < ii; i++) {
-            var path = query.layers[i];
-            if(query.results[path]) {
-                all_features = all_features.concat(query.results[path]);
-            }
-        }
-
-        // when features have been returned, clear out the old features
-        //  and put the new features on the results layer.
-        if(all_features.length > 0) {
-            Application.clearFeatures(this.resultsPath);
-            Application.addFeatures(this.resultsPath, all_features);
-        }
-    }
-
-
 }
 
 if(typeof(module) !== 'undefined') { module.exports = SearchService; }


### PR DESCRIPTION
Adds a new "Buffer All" tool to the Super Tab results
when configured.

Bonus! Fixes bug with buffer-select not showing grid
results.