### PR TITLE
Add Bounding Box and Z/Lon/Lat support to loc param

### DIFF
--- a/src/gm3/actionTypes.js
+++ b/src/gm3/actionTypes.js
@@ -94,6 +94,7 @@ export const MAP = {
     REMOVE_FILTER: 'MAP_REMOVE_FILTER',
 
     SET_EDIT_PATH: 'MAP_SET_EDIT_PATH',
+    RESIZE: 'MAP_RESIZE',
 };
 
 export const TOOLBAR = {

--- a/src/gm3/actions/map.js
+++ b/src/gm3/actions/map.js
@@ -202,3 +202,17 @@ export function setEditPath(editPath) {
         editPath,
     };
 }
+
+/* Set the size of the map in the state as a hint
+ * to other components.
+ *
+ * @param size {Object} an object containing a width and height property.
+ *
+ * @return action definition
+ */
+export function resize(size) {
+    return {
+        type: MAP.RESIZE,
+        size,
+    };
+}

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -966,6 +966,12 @@ class Map extends React.Component {
 
         // once the map is created, kick off the initial startup.
         this.refreshMapSources();
+
+        // note the size of the map
+        this.props.onMapResize({
+            width: this.mapDiv.clientWidth,
+            height: this.mapDiv.clientHeight,
+        });
     }
 
     /** Switch the drawing tool.
@@ -1214,9 +1220,13 @@ class Map extends React.Component {
      *
      * @returns Boolean. True when the map sucessfully sized, false otherwise.
      */
-    updateMapSize() {
+    updateMapSize(width, height) {
         if(this.map && this.mapDiv) {
             this.map.updateSize();
+
+            // this is a hint for other components to calculate
+            //  things based on the map size.
+            // this.props.onMapResize({width, height});
 
             const canvas = this.mapDiv.getElementsByTagName('canvas');
             if(canvas && canvas[0] && canvas[0].style.display !== 'none') {
@@ -1323,6 +1333,12 @@ class Map extends React.Component {
                     this.props.setFeatures('selection', keepers);
                 }
             }
+
+            // note the size of the map
+            this.props.onMapResize({
+                width: this.mapDiv.clientWidth,
+                height: this.mapDiv.clientHeight,
+            });
         }
     }
 
@@ -1385,6 +1401,7 @@ class Map extends React.Component {
 
 Map.defaultProps = {
     services: {},
+    onMapResize: () => {},
 };
 
 function mapState(state) {
@@ -1436,6 +1453,7 @@ function mapDispatch(dispatch) {
         removeFeature: (path, feature) => {
             dispatch(removeFeature(path, feature));
         },
+        onMapResize: size => dispatch(mapActions.resize(size)),
     };
 }
 

--- a/src/gm3/reducers/cursor.js
+++ b/src/gm3/reducers/cursor.js
@@ -30,7 +30,9 @@ import { MAP } from '../actionTypes';
 
 const default_view = {
     coords: [0, 0],
-    sketchGeometry: null
+    sketchGeometry: null,
+    // size can be null by default, this is meant to be a hint only!
+    size: null,
 };
 
 export default function cursorReducer(state = default_view, action) {
@@ -39,6 +41,10 @@ export default function cursorReducer(state = default_view, action) {
             return Object.assign({}, state, {coords: action.coords});
         case MAP.SKETCH_GEOMETRY:
             return Object.assign({}, state, {sketchGeometry: action.geometry});
+        case MAP.RESIZE:
+            return Object.assign({}, state, {
+                size: action.size,
+            });
         default:
             return state;
     }

--- a/tests/gm3/trackers/hash.test.js
+++ b/tests/gm3/trackers/hash.test.js
@@ -1,0 +1,66 @@
+/*
+ * Test the functions which interpret the hash
+ */
+
+// import * as util from 'gm3/util';
+
+import { formatLocation, parseLocation } from 'gm3/trackers/hash';
+
+
+describe('State hashing functions', () => {
+    const state = {
+        map: {
+            center: [-10370905.9, 5552635.8],
+            resolution: 10,
+        },
+        cursor: {
+            size: {
+                width: 200,
+                height: 200,
+            },
+        },
+    };
+
+    describe('Format location for hash', () => {
+        it('handles zxy', () => {
+            const locString = formatLocation(state.map, state.cursor.size, 'zxy');
+            expect(locString).toEqual('10.0000;-10370905.90;5552635.80');
+        });
+
+        it('handles bbox', () => {
+            const locString = formatLocation(state.map, state.cursor.size, 'bbox');
+            expect(locString).toEqual('-93.17242;44.55436;-93.15445;44.56716');
+        });
+
+        it('handles lonlat', () => {
+            const locString = formatLocation(state.map, state.cursor.size, 'lonlat');
+            expect(locString).toEqual('13.93/-93.163433/44.560764');
+        });
+    });
+
+    describe('Parse location from the hash', () => {
+        it('handles a zxy string', () => {
+            const loc = parseLocation('10.0000;-10370905.90;5552635.80');
+            expect(loc).toEqual({
+                resolution: 10.0000,
+                center: [-10370905.90, 5552635.80],
+                zoom: null,
+            });
+        });
+
+        it('handles a bounding box', () => {
+            const loc = parseLocation('-93.17242;44.55436;-93.15445;44.56716');
+            expect(loc).toMatchObject({
+                bbox: [-93.17242, 44.55436, -93.15445, 44.56716],
+            });
+        });
+
+        it('handles lonlat', () => {
+            const loc = parseLocation('13.93/-93.163433/44.560764');
+            expect(loc.resolution).toBeUndefined();
+            expect(loc.zoom).toBeCloseTo(13.93);
+            expect(loc.center[0]).toBeCloseTo(-10370905.9, 1);
+            expect(loc.center[1]).toBeCloseTo(5552635.8, 1);
+        });
+    });
+});


### PR DESCRIPTION
Allow passing in more location formats:

A. `zxy` - the default GeoMoose format since 3.0.
    This is really `map resoltion;center x;center y`.
B. `lonlat` - Which is formatted as `zoom/lon/lat`.
C. `bbox` - Formatted as `west;south;east;north`. In ESPG:4326.

Adds the ability to change the hash emit format as well using
the new option for the HashTracker class. In `app.js`:

```
    var hash_tracker = new gm3.trackers.HashTracker(app.store, {
        locationFormat: 'lonlat'
    });
```