### PR TITLE
Consistently buffer point on line/point queries

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -84,6 +84,7 @@
     <map-source name="vector-parcels" type="mapserver-wfs">
         <file>./demo/parcels/parcels.map</file>
         <param name="typename" value="ms:parcels"/>
+        <config name="pixel-tolerance" value="0"/>
         <transform attribute="EMV_TOTAL" function="number"/>
 
         <layer name="big-money">
@@ -142,9 +143,16 @@
        </layer>
     </map-source>
 
-    <map-source name="pipelines" type="mapserver" title="Pipelines">
+    <map-source name="vector-pipelines" title="Pipelines" type="mapserver-wfs">
+        <param name="typename" value="ms:pipelines"/>
         <file>./demo/pipelines/pipelines.map</file>
         <layer name="pipelines" status="off">
+            <style><![CDATA[
+            {
+                "line-color": "#aaaaff",
+                "line-width": 6
+            }
+            ]]></style>
             <template name="identify"><![CDATA[
             <div>
                 <div class="feature-class pipelines">
@@ -493,7 +501,7 @@
                 <!--layer title="AGS Dakota County Streets" src="ags-vector-dc20/roads"/-->
                 <layer title="AGS Dakota County Runways" src="ags-vector-dc21/runways"></layer>
             </group>
-            <layer src="pipelines/pipelines"></layer>
+            <layer src="vector-pipelines/pipelines"></layer>
             <layer title="Weather Radar" src="iastate/nexrad-n0r" />
         </group>
 

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -524,11 +524,10 @@ class Map extends React.Component {
         };
 
         if (query.selection.length > 0) {
-            let queryGeometry = query.selection[0].geometry;
-
-            queryGeometry = applyPixelTolerance(
-                queryGeometry, map_source,
+            const queryFeature = applyPixelTolerance(
+                query.selection[0], map_source,
                 this.props.mapView.resolution, 2);
+            const queryGeometry = queryFeature.geometry;
 
             // make this an E**I geometry.
             const ol_geom = GEOJSON_FORMAT.readGeometry(queryGeometry);

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -101,6 +101,35 @@ function getControls(mapConfig) {
 const GEOJSON_FORMAT = new GeoJSONFormat();
 
 
+const getPixelTolerance = (querySource, defaultPx = 10) => {
+    // the default pixel tolerance is 10 pixels.
+    let pxTolerance = defaultPx;
+    try {
+        if (querySource.config['pixel-tolerance']) {
+            pxTolerance = parseFloat(querySource.config['pixel-tolerance']);
+        }
+    } catch (err) {
+        // swallow the error
+    }
+    return pxTolerance;
+};
+
+const applyPixelTolerance = (queryFeature, querySource, resolution, defaultPxTolerance) => {
+    const pxTolerance = getPixelTolerance(querySource, defaultPxTolerance);
+    if (pxTolerance > 0 && queryFeature.geometry.type === 'Point') {
+        // buffer point is in pixels,
+        //  this converts pixels to ground units
+        const width = pxTolerance * resolution;
+        return util.getSquareBuffer(
+            queryFeature.geometry.coordinates,
+            width
+        );
+    }
+    return queryFeature;
+};
+
+
+
 class Map extends React.Component {
 
     constructor() {
@@ -334,6 +363,12 @@ class Map extends React.Component {
             output_format = map_source.params.outputFormat;
         }
 
+        if (query.selection.length === 1) {
+            query.selection[0] = applyPixelTolerance(
+                query.selection[0], map_source,
+                this.props.mapView.resolution, 10);
+        }
+
         const wfs_query_xml = buildWfsQuery(query, map_source, map_projection, output_format);
 
         // Ensure all the extra URL params are attached to the
@@ -489,20 +524,12 @@ class Map extends React.Component {
         };
 
         if (query.selection.length > 0) {
-            const queryGeometry = query.selection[0].geometry;
-            // Since AGS servers don't "intersect" a point with anything, we make a box
-            // Make a 4 pixel (2 pixels each way) box around the point
-            if (queryGeometry.type === 'Point'){
-                const res = this.map.getView().getResolution() * 2;
-                const pt = queryGeometry.coordinates;
-                queryGeometry.type = 'Polygon'
-                queryGeometry.coordinates = [[
-                    [pt[0] + res, pt[1] + res],
-                    [pt[0] + res, pt[1] - res],
-                    [pt[0] - res, pt[1] - res],
-                    [pt[0] - res, pt[1] + res]
-                ]]
-            }
+            let queryGeometry = query.selection[0].geometry;
+
+            queryGeometry = applyPixelTolerance(
+                queryGeometry, map_source,
+                this.props.mapView.resolution, 2);
+
             // make this an E**I geometry.
             const ol_geom = GEOJSON_FORMAT.readGeometry(queryGeometry);
 
@@ -1077,29 +1104,11 @@ class Map extends React.Component {
                             querySourceName
                         ];
                         let queryFeature = util.featureToJson(evt.feature);
+
                         const mapProjection = this.map.getView().getProjection();
-
-                        // the default pixel tolerance is 10 pixels.
-                        let pxTolerance = 10;
-                        try {
-                            if (querySource.config['pixel-tolerance']) {
-                                pxTolerance = parseFloat(querySource.config['pixel-tolerance']);
-                            }
-                        } catch (err) {
-                            // swallow the error
-                        }
-
-                        if (pxTolerance > 0) {
-                            // buffer point is in pixels,
-                            //  this converts pixels to ground units
-                            const width = pxTolerance *
-                                this.props.mapView.resolution;
-
-                            queryFeature = util.getSquareBuffer(
-                                queryFeature.geometry.coordinates,
-                                width
-                            );
-                        }
+                        queryFeature = applyPixelTolerance(
+                            queryFeature, querySource,
+                            this.props.mapView.resolution, 10);
 
                         editSrc.clear();
 
@@ -1124,8 +1133,6 @@ class Map extends React.Component {
             } else {
                 const editSrc = this.olLayers[EDIT_LAYER_NAME].getSource();
                 const drawOptions = {
-                    // source: editSrc,
-                    // collection: [],
                     type,
                 };
 
@@ -1140,7 +1147,6 @@ class Map extends React.Component {
                     this.drawTool.on('drawstart', (evt) => {
                         // clear out the other features on the source.
                         source.clear();
-
                         this.sketchFeature = evt.feature;
                     });
                 } else {
@@ -1163,6 +1169,7 @@ class Map extends React.Component {
                                 querySourceName
                             ];
                         }
+
 
                         if (util.parseBoolean(querySource.config['edit-attributes-on-add'], true)) {
                             this.props.setEditPath(path);


### PR DESCRIPTION
- Refactores the pixel-tolerance code to be less inline with
   the query function.
- Changes the AGS query and the WFS query to both use
   pixel-tolerance as defined in the source. (AGS defaults to 2 as before)

Refs: #601