### PR TITLE
Clean up cruft from results config PR

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -37,10 +37,6 @@ var app = new gm3.Application({
             enabled: true,
             units: 'imperial'
         }
-    },
-    results: {
-        enableBufferAll: true,
-        showLayerCount: false,
     }
 });
 

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -32,6 +32,7 @@ import * as mapActions from '../actions/map';
 import { addFeatures, clearFeatures } from '../actions/mapSource';
 import { setUiHint } from '../actions/ui';
 import { getExtentForQuery } from '../util';
+import { DEFAULT_RESULTS_CONFIG } from '../defaults';
 
 import MeasureTool from './measure';
 
@@ -62,13 +63,6 @@ function normalizeSelection(selectionFeatures) {
     }
     return selectionFeatures;
 }
-
-const DEFAULT_CONFIG = {
-    enableBufferAll: false,
-    enableZoomTo: true,
-    showLayerCount: true,
-    showFeatureCount: true,
-};
 
 class ServiceManager extends React.Component {
 
@@ -127,10 +121,7 @@ class ServiceManager extends React.Component {
         const service = this.props.services[query.service];
 
         const resultsConfig = {
-            showFeatureCount: true,
-            showLayerCount: true,
-            showBufferAll: false,
-            showZoomToAll: true,
+            ...this.props.resultsConfig,
             ...service.resultsConfig,
         };
 
@@ -421,7 +412,7 @@ const mapState = state => ({
     queries: state.query,
     map: state.map,
     selectionFeatures: state.mapSources.selection ? state.mapSources.selection.features : [],
-    config: {...DEFAULT_CONFIG, ...state.config.results},
+    resultsConfig: {...DEFAULT_RESULTS_CONFIG, ...state.config.results},
 });
 
 function mapDispatch(dispatch, ownProps) {

--- a/src/gm3/defaults.js
+++ b/src/gm3/defaults.js
@@ -67,3 +67,10 @@ export const EDIT_STYLE = {
 };
 
 export const EDIT_LAYER_NAME = 'edit-temp';
+
+export const DEFAULT_RESULTS_CONFIG = {
+    showBufferAll: false,
+    showZoomToAll: true,
+    showLayerCount: true,
+    showFeatureCount: true,
+};


### PR DESCRIPTION
1. Remove the results config from the demo app.
2. Put the default config in defaults.js
3. Ensure the global defaults are honoured along
   with specific service overrides.

Refs: #655