### PR TITLE
Restore keyboard short cuts for service form

### DIFF
--- a/src/gm3/components/serviceForm.js
+++ b/src/gm3/components/serviceForm.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Dan "Ducky" Little
+ * Copyright (c) 2016-2017, 2021 Dan "Ducky" Little
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -75,6 +75,8 @@ class ServiceForm extends React.Component {
             values: getDefaultValues(this.props.serviceDef),
             validateFieldValuesResultMessage: null,
         };
+
+        this.handleKeyboard = this.handleKeyboardShortcuts.bind(this);
     }
 
     submit() {
@@ -90,9 +92,10 @@ class ServiceForm extends React.Component {
         }
         if (validateFieldValuesResultValid) {
             this.props.onSubmit(this.state.values);
+        } else {
+            // update state validation message
+            this.setState( {validateFieldValuesResultMessage} );
         }
-        // update state validation message
-        this.setState( {validateFieldValuesResultMessage} );
     }
 
     /** Function to handle bashing 'Enter' and causing
@@ -122,6 +125,14 @@ class ServiceForm extends React.Component {
                 validateFieldValuesResultMessage: null,
             });
         }
+    }
+
+    componentDidMount() {
+        document.addEventListener('keyup', this.handleKeyboard);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keyup', this.handleKeyboard);
     }
 
     render() {
@@ -162,12 +173,7 @@ class ServiceForm extends React.Component {
         }
 
         return (
-            <div className='service-form'
-                onKeyUp={(evt) => {
-                    this.handleKeyboardShortcuts(evt);
-                }}
-            >
-
+            <div className='service-form'>
                 <h3>{this.props.t(service_def.title)}</h3>
                 { inputs }
                 {

--- a/src/gm3/components/serviceManager.js
+++ b/src/gm3/components/serviceManager.js
@@ -274,20 +274,6 @@ class ServiceManager extends React.Component {
         this.checkQueries(nextProps.queries);
     }
 
-    /** Function to handle bashing 'Enter' and causing
-     *  the service form to submit.
-     *
-     *  @param evt The event from the div.
-     *
-     */
-    handleKeyboardShortcuts(serviceName, evt) {
-        const code = evt.which;
-        if(code === 13) {
-        } else if(code === 27) {
-            this.props.onServiceFinished();
-        }
-    }
-
     /** Implement a small post-render hack to focus on the first
      *  input element of a service form.
      */

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -113,17 +113,7 @@ function SelectService(Application, options) {
      *                   given to the service.
      */
     this.query = function(selection, fields) {
-        if(typeof(selection) === 'undefined') {
-            // throw up this handy dialog.
-            var msg = 'A selection geometry is required for this query.';
-            var service_name = this.name;
-            var self = this;
-            var on_close = function() {
-                Application.startService(service_name, {changeTool: self.tools.default});
-            };
-
-            Application.alert('selection-required', msg, on_close);
-        } else {
+        if (selection && selection.length > 0) {
             // get the query layer.
             var query_layer = fields[0].value;
             // check which templates should try and load
@@ -137,6 +127,16 @@ function SelectService(Application, options) {
 
             // dispatch the query against on the query layer!
             Application.dispatchQuery(this.name, selection, [], [query_layer], templates);
+        } else {
+            // throw up this handy dialog.
+            var msg = 'A selection geometry is required for this query.';
+            var service_name = this.name;
+            var self = this;
+            var on_close = function() {
+                Application.startService(service_name, {changeTool: self.tools.default});
+            };
+
+            Application.alert('selection-required', msg, on_close);
         }
     }
 


### PR DESCRIPTION
1. Put the keyboard shortcuts on the document instead
   of on the form to make Escape and Enter work properly.
2. Fix state-up issue with `submit()` message.

refs: #632