### PR TITLE
Ensure default properties are saved to property

### DIFF
--- a/src/gm3/components/editor/modal.js
+++ b/src/gm3/components/editor/modal.js
@@ -5,8 +5,16 @@ import Modal from '../modal';
 
 const isNumberType = type => (type === 'number' || type === 'range');
 
-const getDefaultValue = attr =>
-    attr.default ? attr.default : (isNumberType(attr.type) ? 0 : '');
+const getDefaultValue = attr => {
+    const numeric = isNumberType(attr.type);
+    if (attr.default) {
+        return numeric ? parseFloat(attr.default) : attr.default;
+    } else if (numeric) {
+        return 0;
+    } else {
+        return '';
+    }
+}
 
 const getDefaultProperties = attributes => {
     const properties = {};


### PR DESCRIPTION
While property changes were saved, when recalled they
would be undefined, making it difficult to determine
their rendered values. This change requires that all
defaults be set by the properties.

refs: #658