### PR TITLE
set IRC notification to irc.libera.chat server

### DIFF
--- a/.github/workflows/irc_notify.yml
+++ b/.github/workflows/irc_notify.yml
@@ -17,6 +17,7 @@ jobs:
         if: github.event_name == 'push'
         with:
           channel: "#geomoose"
+          server: "irc.libera.chat"
           nickname: geomoose-github-notifier
           message: |
             ${{ github.actor }} pushed ${{ github.event.ref }} ${{ github.event.compare }}
@@ -26,6 +27,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           channel: "#geomoose"
+          server: "irc.libera.chat"          
           nickname: geomoose-github-notifier
           message: |
             ${{ github.actor }} opened PR ${{ github.event.html_url }}
@@ -34,6 +36,7 @@ jobs:
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         with:
           channel: "#geomoose"
+          server: "irc.libera.chat"          
           nickname: geomoose-github-notifier
           message: |
             ${{ github.actor }} tagged ${{ github.repository }} ${{ github.event.ref }}

--- a/.github/workflows/irc_notify.yml
+++ b/.github/workflows/irc_notify.yml
@@ -30,7 +30,7 @@ jobs:
           server: "irc.libera.chat"          
           nickname: geomoose-github-notifier
           message: |
-            ${{ github.actor }} opened PR ${{ github.event.html_url }}
+            ${{ github.actor }} opened PR ${{ github.event.pull_request.html_url }}
       - name: irc tag created
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'create' && github.event.ref_type == 'tag'


### PR DESCRIPTION
- recent turmoil on Freenode servers, most have moved to the community-based irc.libera.chat server
- the GitHub action `notify-irc` also now sets the default server to be irc.libera.chat (https://github.com/rectalogic/notify-irc/pull/4)
- this pull request sets the default server by name