### PR TITLE
Add "select" type for property editors

### DIFF
--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -117,6 +117,18 @@ function parseProperties(msXml) {
                 }
             }
 
+            // parse the select options.
+            if (propDef.type === 'select') {
+                propDef.options = []
+                const options = prop.getElementsByTagName('option');
+                for (let x = 0, xx = options.length; x < xx; x++) {
+                    propDef.options.push({
+                        value: options[x].getAttribute('value'),
+                        label: util.getXmlTextContents(options[x]),
+                    });
+                }
+            }
+
             props.push(propDef);
         }
     }

--- a/src/gm3/components/editor/modal.js
+++ b/src/gm3/components/editor/modal.js
@@ -105,6 +105,16 @@ export class EditorModal extends Modal {
                 });
         }
 
+        if (type === 'select') {
+            return (
+                <select {...props}>
+                    {attr.options.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                </select>
+            );
+        }
+
         return (
             <input
                 {...props}


### PR DESCRIPTION
This provides an enumerated type for editing.

```
...

<property type="select" label="Encoding" default="dec">
    <option value="dec">Decimal</option>
    <option value="oct">Octal</option>
    <option value="hex">Hexadecimal</option>
</property>
...
```

refs: #47