### PR TITLE
Fix state bug with zoom to extent and document

### DIFF
--- a/docs/howto/start-at-extent.rst
+++ b/docs/howto/start-at-extent.rst
@@ -1,0 +1,28 @@
+How-to Start at Extent
+======================
+
+Sometimes it is easier to start the application by framing a specific spatial
+extent instead of a known center-point and zoom level.
+
+Remove the example setView
+--------------------------
+
+Remove the following lines:
+
+::
+
+    app.setView({
+        center: app.lonLatToMeters( -93.16, 44.55),
+        zoom: 12
+    });
+
+Add zoomToExtent
+----------------
+
+The first parameter is an array of [minx, miny, maxx, maxy] and the
+second parameter is an optional projection string. The default projection
+is Web Mercator.
+
+::
+
+    app.zoomToExtent([-93.3,44.47,-93.0, 44.63], 'EPSG:4326');

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -965,6 +965,10 @@ class Map extends React.Component {
             controls: getControls(this.props.config),
         });
 
+        if (this.props.mapView.extent) {
+            this.zoomToExtent(this.props.mapView.extent);
+        }
+
         // when the map moves, dispatch an action
         this.map.on('moveend', () => {
             // get the view of the map
@@ -1252,21 +1256,24 @@ class Map extends React.Component {
         return false;
     }
 
+    zoomToExtent(extent) {
+        let bbox = extent.bbox;
+        const bbox_code = extent.projection;
+        if(bbox_code) {
+            const map_proj = this.map.getView().getProjection();
+            bbox = proj.transformExtent(bbox, proj.get(bbox_code), map_proj);
+        }
+        // move the map to the new extent.
+        this.map.getView().fit(bbox, {size: this.map.getSize()});
+    }
+
     /** Intercept extent changes during a part of the render
      *  cycle where the state can get modified.
      */
     componentDidUpdate(prevProps) {
         // extent takes precendent over the regular map-view,
         if(this.props.mapView.extent) {
-            let bbox = this.props.mapView.extent.bbox;
-            const bbox_code = this.props.mapView.extent.projection;
-            if(bbox_code) {
-                const map_proj = this.map.getView().getProjection();
-                bbox = proj.transformExtent(bbox, proj.get(bbox_code), map_proj);
-            }
-            // move the map to the new extent.
-            this.map.getView().fit(bbox, {size: this.map.getSize()});
-
+            this.zoomToExtent(this.props.mapView.extent);
         // check to see if the view has been altered.
         } else if(this.props.mapView) {
             const map_view = this.map.getView();


### PR DESCRIPTION
1. Fixed a startup-view bug with `zoomToExtent`.
2. Added documentation on how to start from an extent.

refs: #564