### PR TITLE
Fix for highlight bug when multiple layers are on

### DIFF
--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -797,8 +797,6 @@ class Map extends React.Component {
         if(this.props.mapSources.results) {
             // clear the features
             this.props.store.dispatch(mapSourceActions.clearFeatures('results', 'results'));
-            // get the path to the first set of features
-            const layer_path = Object.keys(query.results)[0];
 
             let features = [];
             for (const layer_path in query.results) {

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -800,13 +800,16 @@ class Map extends React.Component {
             // get the path to the first set of features
             const layer_path = Object.keys(query.results)[0];
 
-            // ensure the layer_path does not have a failure.
-            if(query.results[layer_path].failed !== true) {
-                // get the features, after applying the query filter
-                const features = util.matchFeatures(query.results[layer_path], query.filter);
-                // render only those features.
-                this.props.store.dispatch(mapSourceActions.addFeatures('results', features));
+            let features = [];
+            for (const layer_path in query.results) {
+                // ensure the layer_path does not have a failure.
+                if(query.results[layer_path].failed !== true) {
+                    // get the features, after applying the query filter
+                    features = features.concat(util.matchFeatures(query.results[layer_path], query.filter));
+                }
             }
+            // render the features from all the layers
+            this.props.store.dispatch(mapSourceActions.addFeatures('results', features));
         } else {
             console.error('No "results" layer has been defined, cannot do smart query rendering.');
         }


### PR DESCRIPTION
The results-list should have built for multiple layers instead
of just the first. This change converts the single layer check
to a loop.

Also, a fixed required to prevent issues with the `fs` module.

refs: #576, #577