### PR TITLE
Fix for broken buffer all

### DIFF
--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -1144,7 +1144,7 @@ class Map extends React.Component {
                 this.drawTool = new olModifyInteraction({
                     features: new olCollection(features),
                 });
-            } else {
+            } else if (type !== '') {
                 const editSrc = this.olLayers[EDIT_LAYER_NAME].getSource();
                 const drawOptions = {
                     type,


### PR DESCRIPTION
Drawing tool refactoring broke the buffer all tool.
This adds a check to ensure that there is a valid draw
tool to activate on the map.

refs: #699