### PR TITLE
Add ability to create a search example

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -101,7 +101,7 @@ app.loadMapbook().then(function() {
 
     app.registerService('search', SearchService, {
         fields: [
-            {type: 'text', label: 'Owner Name', name: 'OWNER_NAME'},
+            {type: 'text', label: 'Owner Name', example: '(i.e. Johnson)' name: 'OWNER_NAME'},
             {type: 'text', label: 'Street/Address', name: 'OWN_ADD_L1'},
             {type: 'text', label: 'City/State/ZIP', name: 'OWN_ADD_L3'}
         ],

--- a/src/gm3/components/serviceInputs/text.js
+++ b/src/gm3/components/serviceInputs/text.js
@@ -71,6 +71,7 @@ export default class TextInput extends Component {
         return (
             <div className='service-input'>
                 <label htmlFor={ 'input-' + id }>{ this.props.field.label }</label>
+                <example htmlFor={ 'input-' + id }>{ this.props.field.example }</example>
                 <input onChange={this.onChange} value={this.state.value} type="text" id={ 'input-' + id}></input>
             </div>
         );

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -92,6 +92,11 @@
             display: block;
             margin-top: 7px;
         }
+        
+        example {
+            display: block;
+            font-size: 0.8em;
+        }
 
         select, input {
             margin-left: 5px;


### PR DESCRIPTION
This allows admins to configure examples for the searches so users need to spend less effort figuring out the format of the data:

![image](https://user-images.githubusercontent.com/43766648/157719521-f49f94c0-b5c5-448a-9e29-b2a0087d3597.png)
