### PR TITLE
Add placeholder and helper text to inputs

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -101,9 +101,9 @@ app.loadMapbook().then(function() {
 
     app.registerService('search', SearchService, {
         fields: [
-            {type: 'text', label: 'Owner Name', name: 'OWNER_NAME'},
+            {type: 'text', label: 'Owner Name', name: 'OWNER_NAME', helpText: '(i.e. Johnson)'},
             {type: 'text', label: 'Street/Address', name: 'OWN_ADD_L1'},
-            {type: 'text', label: 'City/State/ZIP', name: 'OWN_ADD_L3'}
+            {type: 'text', label: 'City/State/ZIP', name: 'OWN_ADD_L3', placeHolder: 'Farmington'}
         ],
         searchLayers: ['vector-parcels/parcels'],
         validateFieldValues: function (fields) {

--- a/src/gm3/components/serviceInputs/text.js
+++ b/src/gm3/components/serviceInputs/text.js
@@ -71,9 +71,18 @@ export default class TextInput extends Component {
         return (
             <div className='service-input'>
                 <label htmlFor={ 'input-' + id }>{ this.props.field.label }</label>
-                <input onChange={this.onChange} value={this.state.value} type="text" id={ 'input-' + id}></input>
+                <input
+                    onChange={this.onChange}
+                    value={this.state.value}
+                    type="text"
+                    id={ 'input-' + id}
+                    placeholder={ this.props.field.placeHolder }
+                    className={this.props.field.helpText ? 'has-help-text' : ''}
+                />
+                {this.props.field.helpText && (
+                    <div className="helper-text" htmlFor={ 'input-' + id }>{ this.props.field.helpText }</div>
+                )}
             </div>
         );
     }
-
 }

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -104,6 +104,17 @@
                 width: 10em;
             }
         }
+
+        input.has-help-text {
+            margin-bottom: 0;
+        }
+
+        div.helper-text {
+            font-size: 0.8em;
+            margin-bottom: 1.5em;
+            /* put this 1px inside of the input */
+            margin-left: 6px;
+        }
     }
 
     input[type='text'] {


### PR DESCRIPTION
Allow the administrator to add either helper text (an example
below the input) or a HTML based placehodler to the service forms.