### PR TITLE
Allow turning off highlight for a layer and service

### DIFF
--- a/docs/howto/exclude-from-highlight.rst
+++ b/docs/howto/exclude-from-highlight.rst
@@ -1,0 +1,21 @@
+How-to Exclude a Layer From Highlight
+=====================================
+
+To keep a layer from highlighting on a specific service,
+add `highlight=false` to the `template` definition.
+
+
+For example:
+
+::
+
+    <map-source ...>
+        <layer ...>
+            <template name="identify" highlight="false">
+                ...
+            </template>
+        </layer>
+    </map-source>
+
+This will prevent the features from being included in the highlight
+layer when found with identify.

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -153,7 +153,7 @@
                 "line-width": 6
             }
             ]]></style>
-            <template name="identify"><![CDATA[
+            <template name="identify" highlight="false"><![CDATA[
             <div>
                 <div class="feature-class pipelines">
                 Pipeline

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -358,7 +358,7 @@ export function addFromXml(xml, config) {
                     contents: util.getXmlTextContents(template_xml)
                 };
             }
-
+            template_def.highlight = util.parseBoolean(template_xml.getAttribute('highlight')) !== false;
             layer.templates[template_name] = template_def;
         }
 

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -442,8 +442,9 @@ class Application {
                                     mapSourceActions.setLayerTemplate(
                                         ms_name, layer_name,
                                         template_name, {
+                                            ...layer_template,
                                             type: 'local',
-                                            contents: content
+                                            contents: content,
                                         }
                                     )
                                 );

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -795,19 +795,23 @@ class Map extends React.Component {
      */
     renderQueryLayer(query) {
         if(this.props.mapSources.results) {
-            // clear the features
-            this.props.store.dispatch(mapSourceActions.clearFeatures('results', 'results'));
-
             let features = [];
             for (const layer_path in query.results) {
                 // ensure the layer_path does not have a failure.
-                if(query.results[layer_path].failed !== true) {
-                    // get the features, after applying the query filter
-                    features = features.concat(util.matchFeatures(query.results[layer_path], query.filter));
+                if (query.results[layer_path].failed !== true) {
+                    const layer = mapSourceActions.getLayerFromPath(this.props.mapSources, layer_path);
+                    let highlight = true;
+                    if (layer.templates[query.service]) {
+                        highlight = layer.templates[query.service].highlight !== false;
+                    }
+                    if (highlight) {
+                        // get the features, after applying the query filter
+                        features = features.concat(util.matchFeatures(query.results[layer_path], query.filter));
+                    }
                 }
             }
             // render the features from all the layers
-            this.props.store.dispatch(mapSourceActions.addFeatures('results', features));
+            this.props.setFeatures('results', features);
         } else {
             console.error('No "results" layer has been defined, cannot do smart query rendering.');
         }


### PR DESCRIPTION
Setting `highlight="false"` on a template will keep
the layer from behing highlighted when found using
the related service.

refs: #695 