### PR TITLE
Ensure that highlight defaults to true

### DIFF
--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -358,7 +358,7 @@ export function addFromXml(xml, config) {
                     contents: util.getXmlTextContents(template_xml)
                 };
             }
-            template_def.highlight = util.parseBoolean(template_xml.getAttribute('highlight')) !== false;
+            template_def.highlight = util.parseBoolean(template_xml.getAttribute('highlight'), true) !== false;
             layer.templates[template_name] = template_def;
         }
 


### PR DESCRIPTION
The parser was treating undefined as `false` which
is the opposite of the desired behavior.

refs: #738