### PR TITLE
Make startService async

### DIFF
--- a/src/gm3/actions/query.js
+++ b/src/gm3/actions/query.js
@@ -9,12 +9,23 @@ import { getMapSourceName } from '../util';
 import { changeTool, setSelectionBuffer, clearSelectionFeatures, addSelectionFeature } from './map';
 import { clearFeatures, addFeatures } from './mapSource';
 
-export const startService = createAction('query/start-service', (serviceName, defaultValues = {}) => ({
+export const changeService = createAction('query/change-service', (serviceName, defaultValues = {}) => ({
     payload: {
         serviceName,
         defaultValues,
     },
 }));
+
+export const startService = createAsyncThunk('query/start-service', ({serviceName, defaultValues = {}}, {getState, dispatch}) => {
+    const state = getState();
+
+    if (state.query.serviceName !== serviceName) {
+        // clear the selection features
+        dispatch(clearSelectionFeatures());
+        dispatch(clearFeatures('selection'));
+    }
+    dispatch(changeService(serviceName, defaultValues));
+});
 
 export const finishService = createAction('query/finish-service');
 
@@ -103,7 +114,7 @@ export const bufferResults = createAsyncThunk('query/buffer-results', (arg, {get
         dispatch(clearFeatures('selection'));
         dispatch(addFeatures('selection', features));
 
-        dispatch(startService('buffer-select'));
+        dispatch(changeService('buffer-select'));
     } else {
         // TODO: Dispatch an error message that it
         //       it is not possible to buffer nothing.

--- a/src/gm3/actions/query.js
+++ b/src/gm3/actions/query.js
@@ -22,7 +22,9 @@ export const startService = createAsyncThunk('query/start-service', ({serviceNam
     if (state.query.serviceName !== serviceName) {
         // clear the selection features
         dispatch(clearSelectionFeatures());
-        dispatch(clearFeatures('selection'));
+        if (state.mapSources.selection) {
+            dispatch(clearFeatures('selection'));
+        }
     }
     dispatch(changeService(serviceName, defaultValues));
 });

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -757,7 +757,7 @@ class Application {
             this.store.dispatch(mapSourceActions.addFeatures('selection', options.withFeatures));
         }
 
-        this.store.dispatch(startService(serviceName, options.defaultValues));
+        this.store.dispatch(startService({serviceName, defaultValues: options.defaultValues}));
 
         // when autoGo is set to true, the service will
         //   start the query.

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -743,21 +743,7 @@ class Application {
             ? options.changeTool
             : serviceDef.tools.default;
 
-        this.store.dispatch(mapActions.changeTool(nextTool));
-
-        if (options && options.withFeatures) {
-            // reset the buffer when adding features.
-            this.store.dispatch(mapActions.setSelectionBuffer(0));
-            // dispatch the features
-            this.store.dispatch(mapActions.clearSelectionFeatures());
-            options.withFeatures.forEach(feature => {
-                this.store.dispatch(mapActions.addSelectionFeature(feature));
-            });
-            this.store.dispatch(mapSourceActions.clearFeatures('selection'));
-            this.store.dispatch(mapSourceActions.addFeatures('selection', options.withFeatures));
-        }
-
-        this.store.dispatch(startService({serviceName, defaultValues: options.defaultValues}));
+        this.store.dispatch(startService({serviceName, defaultTool: nextTool, defaultValues: options.defaultValues, withFeatures: options.withFeatures}));
 
         // when autoGo is set to true, the service will
         //   start the query.
@@ -768,8 +754,6 @@ class Application {
             const fields = normalizeFieldValues(serviceDef, options.defaultValues);
             serviceDef.query(selection, fields);
         }
-
-        this.store.dispatch(uiActions.setUiHint('service-start'));
     }
 
     /** Handle updating the UI, does nothing in vanilla form.

--- a/src/gm3/components/serviceManager/index.js
+++ b/src/gm3/components/serviceManager/index.js
@@ -31,7 +31,7 @@ const ServiceManager = function({
 
     // when the service name changes, reset the field values
     useEffect(() => {
-        setServiceReady(false);
+        setServiceReady(-1);
         setFieldValues({});
     }, [serviceDef]);
 

--- a/src/gm3/components/toolbar/button.js
+++ b/src/gm3/components/toolbar/button.js
@@ -99,7 +99,7 @@ function mapDispatch(dispatch, ownProps) {
                 }
 
                 // start the service
-                dispatch(startService(tool.name));
+                dispatch(startService({serviceName: tool.name}));
                 // give an indication that a new service has been started
                 dispatch(setUiHint('service-start'));
             } else if(tool.actionType === 'action') {

--- a/src/gm3/reducers/query.js
+++ b/src/gm3/reducers/query.js
@@ -28,7 +28,7 @@
 
 import { createReducer } from '@reduxjs/toolkit';
 import {
-    startService, finishService, createQuery, runQuery, addFilter, removeFilter, setHotFilter, removeQueryResults
+    changeService, finishService, createQuery, runQuery, addFilter, removeFilter, setHotFilter, removeQueryResults
 } from '../actions/query';
 import { filterFeatures, getFilterFieldNames } from '../util';
 
@@ -52,7 +52,7 @@ const defaultState = {
 };
 
 const reducer = createReducer(defaultState, {
-    [startService]: (state, {payload: {serviceName, defaultValues}}) => {
+    [changeService]: (state, {payload: {serviceName, defaultValues}}) => {
         // the instance counter is used to delineate between
         //  simultaneous calls to the same service.
         state.instance += 1;

--- a/tests/gm3/components/toolbar.test.js
+++ b/tests/gm3/components/toolbar.test.js
@@ -25,17 +25,12 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
-import { createStore, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
+import { createStore } from 'gm3/store';
 
 import SmartToolbar, { Toolbar } from 'gm3/components/toolbar';
 import SmartToolbarButton, { ToolbarButton } from 'gm3/components/toolbar/button';
 import ToolbarDrawer from 'gm3/components/toolbar/drawer';
-
-import toolbarReducer from 'gm3/reducers/toolbar';
-import queryReducer from 'gm3/reducers/query';
-import mapReducer from 'gm3/reducers/map';
-import uiReducer from 'gm3/reducers/ui';
 
 import * as actions from 'gm3/actions/toolbar';
 
@@ -44,12 +39,7 @@ describe('Toolbar component tests', () => {
     let store = null;
 
     beforeEach(() => {
-        store = createStore(combineReducers({
-            toolbar: toolbarReducer,
-            map: mapReducer,
-            query: queryReducer,
-            ui: uiReducer,
-        }));
+        store = createStore();
     });
 
     it('renders a toolbar button', () => {


### PR DESCRIPTION
- Allows for composing the reset actions in the action instead of throughout components/reducers.
- Fixes but where an autoGo service was using the wrong geometry when switching services.
- Consolidates the logic between the application.js API and the toolbar button API.

refs: #750