### PR TITLE
Fix grid template references

### DIFF
--- a/docs/howto/add-grid-to-search-and-identify.rst
+++ b/docs/howto/add-grid-to-search-and-identify.rst
@@ -25,3 +25,25 @@ The search example is shown below:
 
         <template name="search-grid-columns" src="./templates/parcel-columns.json" />
         <template name="search-grid-row" src="./templates/parcel-row.html" />
+
+Re-using templates in other services
+------------------------------------
+
+It can be useful to use the same templates for different services. For example,
+if the same data should be returned for two different types of search templates.
+
+To add the grid results, using the ``search`` templates to ``single-search`` make
+the following changes to ``app.js``:
+
+::
+
+    app.registerService('single-search', SearchService, {
+        ...
+        zoomToResults: true,
+        // this will enable the grid
+        showGrid: true,
+        // this tells GeoMoose to use "search" templates instead of "single-search"
+        alias: 'search'
+    });
+
+

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -117,8 +117,9 @@ function SearchService(Application, options) {
         // check which templates should try and load
         var templates = [this.template];
         if (this.showGrid) {
-            templates.push('@search-grid-columns');
-            templates.push('@search-grid-row');
+            const templateName = !!this.alias ? this.alias : this.name;
+            templates.push('@' + templateName + '-grid-columns');
+            templates.push('@' + templateName + '-grid-row');
         }
 
         // Application.dispatchQuery is used to query a set of map-sources

--- a/src/services/select.js
+++ b/src/services/select.js
@@ -119,8 +119,9 @@ function SelectService(Application, options) {
             // check which templates should try and load
             var templates = [this.template];
             if(this.showGrid) {
-                templates.push('@select-grid-columns');
-                templates.push('@select-grid-row');
+                const templateName = !!this.alias ? this.alias : this.name;
+                templates.push('@' + templateName + '-grid-columns');
+                templates.push('@' + templateName + '-grid-row');
                 templates.push('@gridColumns');
                 templates.push('@gridRow');
             }


### PR DESCRIPTION
Grid templates were making assumptions about the service name, this fixes that and honors the `alias` setting.

refs: #684