### PR TITLE
Fix row events for virtualized table

### DIFF
--- a/examples/desktop/templates/parcel-row.html
+++ b/examples/desktop/templates/parcel-row.html
@@ -1,6 +1,6 @@
 <tr
   onmouseenter="app.highlightFeatures({'PIN' : '{{ properties.PIN }}'}, true)"
-  onmouseleave="app.clearHighlight()"
+  onmouseleave="app.clearHighlight(); console.log('leave...')"
 >
     <td>
       {{ properties.PIN }}


### PR DESCRIPTION
Parses the `<tr/>` and checks for any events set in the template.

This fixes issue #760 