### PR TITLE
Fix broken location restoration

### DIFF
--- a/src/gm3/reducers/map.js
+++ b/src/gm3/reducers/map.js
@@ -75,6 +75,7 @@ const reducer = createReducer(defaultState, {
     }
     if (Boolean(payload.resolution)) {
       state.resolution = payload.resolution;
+      state.zoom = null;
     }
   },
   [zoomToExtent]: (state, { payload }) => {


### PR DESCRIPTION
In the old reducer, `zoom` would be removed from the state when zooming by resolution. If `zoom` is set the map honors that first, causing a logic issue and the `resolution` to not be honored.

This sets `zoom = null` to prevent that logic issue.

refs: #813 