### PR TITLE
Update mapbook mapfile paths to avoid './'

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -82,7 +82,7 @@
     </map-source>
 
     <map-source name="vector-parcels" type="mapserver-wfs">
-        <file>./demo/parcels/parcels.map</file>
+        <file>demo/parcels/parcels.map</file>
         <param name="typename" value="ms:parcels"/>
         <config name="pixel-tolerance" value="0"/>
         <transform attribute="EMV_TOTAL" function="number"/>
@@ -145,7 +145,7 @@
 
     <map-source name="vector-pipelines" title="Pipelines" type="mapserver-wfs">
         <param name="typename" value="ms:pipelines"/>
-        <file>./demo/pipelines/pipelines.map</file>
+        <file>demo/pipelines/pipelines.map</file>
         <layer name="pipelines" status="off">
             <style><![CDATA[
             {
@@ -172,13 +172,13 @@
 
     <!-- Demo of parcels as points. -->
     <map-source name="parcels_points" type="mapserver" up="true" down="true" title="Parcel Points" minresolution="100" maxresolution="5000">
-        <file>./demo/parcels/parcels.map</file>
+        <file>demo/parcels/parcels.map</file>
         <layer name="parcels_points"/>
         <param name="FORMAT" value="image/png"/>
     </map-source>
 
     <map-source name="parcels" type="mapserver" up="true" down="true" title="Parcels">
-        <file>./demo/parcels/parcels.map</file>
+        <file>demo/parcels/parcels.map</file>
         <layer name="parcels" status="on" query-as="vector-parcels/parcels" />
         <layer name="parcels_points"/>
         <param name="FORMAT" value="image/png"/>
@@ -193,7 +193,7 @@
      * This map-source is used solely for testing geomose for scale issues
      -->
     <map-source name="grids" type="mapserver" up="true" down="true" title="Grids">
-        <file>./demo/grids/grids.map</file>
+        <file>demo/grids/grids.map</file>
         <param name="FORMAT" value="image/png"/>
         <layer name="grid_1km"/>
         <layer name="grid_1mile"/>
@@ -204,12 +204,12 @@
      * with international characters.
      -->
     <map-source name="international" type="mapserver">
-        <file>./demo/i18n/utf8_polys.map</file>
+        <file>demo/i18n/utf8_polys.map</file>
         <layer name="testing"/>
     </map-source>
 
     <map-source name="borders" type="mapserver" title="City and County Borders">
-        <file>./demo/statedata/basemap.map</file>
+        <file>demo/statedata/basemap.map</file>
         <layer name="city_poly" status="off"/>
         <layer name="county_borders" status="off"/>
     </map-source>
@@ -444,13 +444,13 @@
     </map-source>
 
     <map-source name="usgs" type="mapserver">
-        <file>./demo/wms/wms_proxy.map</file>
+        <file>demo/wms/wms_proxy.map</file>
         <layer name="usgs_imagery"/>
         <layer name="usgs_topo"/>
     </map-source>
 
     <map-source name="lmic" type="mapserver">
-        <file>./demo/wms/wms_proxy.map</file>
+        <file>demo/wms/wms_proxy.map</file>
         <layer name="mncomp">
             <legend type="nolegend"/>
         </layer>

--- a/examples/mobile/mapbook.xml
+++ b/examples/mobile/mapbook.xml
@@ -4,7 +4,7 @@
 		The mapping services define the source of the mapping data.
 	-->
     <map-source name="vector-parcels" type="mapserver-wfs">
-        <file>./demo/parcels/parcels.map</file>
+        <file>demo/parcels/parcels.map</file>
         <param name="typename" value="ms:parcels"/>
         <transform attribute="EMV_TOTAL" function="number"/>
 
@@ -42,7 +42,7 @@
     </map-source>
 
 	<map-source name="pipelines" type="mapserver" title="Pipelines">
-		<file>./demo/pipelines/pipelines.map</file>
+		<file>demo/pipelines/pipelines.map</file>
 		<layer name="pipelines" status="off">
             <template name="identify"><![CDATA[
             <div>
@@ -64,14 +64,14 @@
 	<!-- Demo of parcels as points. -->
     <!--
 	<map-source name="parcel_points" type="mapserver" up="true" down="true" title="Parcel Points">
-		<file>./demo/parcels/parcels.map</file>
+		<file>demo/parcels/parcels.map</file>
 		<layer name="parcel_points"/>
 		<param name="FORMAT" value="image/png"/>
 	</map-source>
     -->
 
 	<map-source name="parcels" type="mapserver" up="true" down="true" title="Parcels">
-		<file>./demo/parcels/parcels.map</file>
+		<file>demo/parcels/parcels.map</file>
 		<layer name="parcels" status="on">
             <template name="identify"><![CDATA[
                 <div class="identify-result">
@@ -99,12 +99,12 @@
 	 * with international characters.
 	 -->
 	<map-source name="international" type="mapserver">
-		<file>./demo/i18n/utf8_polys.map</file>
+		<file>demo/i18n/utf8_polys.map</file>
 		<layer name="testing"/>
 	</map-source>
 
 	<map-source name="borders" type="mapserver" title="City and County Borders">
-		<file>./demo/statedata/basemap.map</file>
+		<file>demo/statedata/basemap.map</file>
 		<layer name="city_poly" status="off"/>
 		<layer name="county_borders" status="off"/>
 	</map-source>
@@ -267,13 +267,13 @@
 	</map-source>
 
 	<map-source name="usgs" type="mapserver">
-		<file>./demo/wms/wms_proxy.map</file>
+		<file>demo/wms/wms_proxy.map</file>
 		<layer name="usgs_imagery"/>
 		<layer name="usgs_topo"/>
 	</map-source>
 
 	<map-source name="lmic" type="mapserver">
-		<file>./demo/wms/wms_proxy.map</file>
+		<file>demo/wms/wms_proxy.map</file>
 		<layer name="mncomp">
             <legend type="nolegend"/>
         </layer>


### PR DESCRIPTION
Needed for MapServer 7.6.4 map= validation.

(I really thought we already did this.)