### PR TITLE
Prevent padding from creating a "zoom out" effect

### DIFF
--- a/src/gm3/actions/map.js
+++ b/src/gm3/actions/map.js
@@ -30,10 +30,11 @@ import { createAction } from "@reduxjs/toolkit";
 
 export const zoomToExtent = createAction(
   "map/zoom-to-extent",
-  (extent, projection) => ({
+  (extent, projection, padding = true) => ({
     payload: {
       extent,
       projection,
+      padding,
     },
   })
 );

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -768,10 +768,15 @@ class Map extends React.Component {
       const mapProj = this.map.getView().getProjection();
       bbox = proj.transformExtent(bbox, proj.get(bboxCode), mapProj);
     }
+    const options = {
+      size: this.map.getSize(),
+    };
+    // if the bbox was an exact capture, then do not pad.
+    if (extent.padding !== false) {
+      options.padding = [15, 15, 15, 15];
+    }
     // move the map to the new extent.
-    this.map
-      .getView()
-      .fit(bbox, { size: this.map.getSize(), padding: [15, 15, 15, 15] });
+    this.map.getView().fit(bbox, options);
   }
 
   /** Intercept extent changes during a part of the render

--- a/src/gm3/reducers/map.js
+++ b/src/gm3/reducers/map.js
@@ -82,6 +82,8 @@ const reducer = createReducer(defaultState, {
     state.extent = {
       bbox: payload.extent,
       projection: payload.projection,
+      // default to having padding if undefined.
+      padding: payload.padding !== undefined ? payload.padding : true,
     };
   },
   [changeTool]: (state, { payload }) => {

--- a/src/gm3/trackers/hash.js
+++ b/src/gm3/trackers/hash.js
@@ -240,7 +240,7 @@ export default class HashTracker {
     //  not parseable.
     if (next) {
       if (next.bbox) {
-        this.store.dispatch(zoomToExtent(next.bbox, "EPSG:4326"));
+        this.store.dispatch(zoomToExtent(next.bbox, "EPSG:4326", false));
       } else {
         this.store.dispatch(setView(next));
       }


### PR DESCRIPTION
By default, `zoomToExtent` will pad the extent by 15 pixels. This adds an option to prevent that padding from happening when the tracker reloads a bounding box.

refs: #823