### PR TITLE
Fix broken `image_data`

### DIFF
--- a/src/gm3/components/print/printModal.js
+++ b/src/gm3/components/print/printModal.js
@@ -182,9 +182,16 @@ export class PrintModal extends Modal {
   addImage(doc, def) {
     // optionally scale the image to fit the space.
     if (def.width && def.height) {
-      doc.addImage(def.imageData, def.x, def.y, def.width, def.height);
+      // image_data is included here for backwards compatibility.
+      doc.addImage(
+        def.image_data || def.imageData,
+        def.x,
+        def.y,
+        def.width,
+        def.height
+      );
     } else {
-      doc.addImage(def.imageData, def.x, def.y);
+      doc.addImage(def.image_data || def.imageData, def.x, def.y);
     }
   }
 


### PR DESCRIPTION
Fixing camel case variables got aggressive. This rights that wrong in the `image_data` case for print templates.

refs: #810 