### PR TITLE
allow bookmark with query

### DIFF
--- a/src/gm3/components/bookmark-modal.js
+++ b/src/gm3/components/bookmark-modal.js
@@ -33,7 +33,7 @@ class BookmarkModal extends Modal {
       <div>
         <label>This url can be copied and pasted to make a bookmark:</label>
         <a
-          href={"" + document.location}
+          href={"" + document.location.toString().replace(/\?.*#/, "#")}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -46,7 +46,7 @@ class BookmarkModal extends Modal {
             height: "200px",
             fontFamily: "mono",
           }}
-          defaultValue={"" + document.location}
+          defaultValue={"" + document.location.toString().replace(/\?.*#/, "#")}
         />
       </div>
     );


### PR DESCRIPTION
3.11, when configured by the admin, allowed users to start queries from the url. This is retained in the bookmark url, meaning when someone uses the bookmark tool after a url query, the query will run overwriting any extent changes.

This uses a regular expression when creating the bookmark url similar to how geomoose 2 handled it, replacing everything between the ? and # in the URL, removing the service parameters.

Ref: https://github.com/geomoose/gm3/issues/831