### PR TITLE
Fix background-color typo in gm3.less

### DIFF
--- a/src/less/gm3.less
+++ b/src/less/gm3.less
@@ -105,5 +105,5 @@ button {
     border: 0;
     border-radius: 8px;
     padding: 12px;
-    bdckground-color: #d5d0d0;
+    background-color: #d5d0d0;
 }


### PR DESCRIPTION
There's a typo in the background-color setting for buttons that ends up in the geomoose.css file when the GeoMoose package is built.