### PR TITLE
Honor filtered results in the super tab

### DIFF
--- a/src/gm3/actions/query.js
+++ b/src/gm3/actions/query.js
@@ -5,6 +5,7 @@ import { vectorFeatureQuery } from "../query/vector";
 import { wfsGetFeatureQuery } from "../query/wfs";
 import { wmsGetFeatureInfoQuery } from "../query/wms";
 import { getMapSourceName } from "../util";
+import { getQueryResults } from "../selectors/query";
 
 import {
   changeTool,
@@ -152,13 +153,14 @@ export const bufferResults = createAsyncThunk(
   "query/buffer-results",
   (arg, { getState, dispatch }) => {
     const state = getState();
-    const query = state.query;
+    const results = getQueryResults(state);
+    console.log("RESULTS=", results);
 
     // flatten the query results down to just a
     //  list of features
     let features = [];
-    for (const path in query.results) {
-      features = features.concat(query.results[path]);
+    for (const path in results) {
+      features = features.concat(results[path]);
     }
 
     if (features.length > 0) {

--- a/src/gm3/components/serviceManager/results.js
+++ b/src/gm3/components/serviceManager/results.js
@@ -28,7 +28,8 @@ export const QueryResults = ({
   const queryId = "query-id-0";
   const queryDef = {
     ...query,
-    results: allResults,
+    // this will filter down to just matching results
+    results,
   };
 
   const zoomToResults = useCallback(() => {
@@ -66,13 +67,16 @@ export const QueryResults = ({
   const serviceTitle = serviceDef.resultsTitle || `${serviceDef.title} Results`;
 
   let layerCount = 0,
-    allFeatureCount = 0,
-    featureCount = results.length;
+    allFeatureCount = 0;
   for (const path in allResults) {
     if (allResults[path].failed !== true) {
       layerCount += 1;
       allFeatureCount += allResults[path].length;
     }
+  }
+  let featureCount = 0;
+  for (const path in results) {
+    featureCount += results[path].length;
   }
 
   const bufferEnabled = featureCount <= config.bufferMaxFeatures;

--- a/src/gm3/selectors/query.js
+++ b/src/gm3/selectors/query.js
@@ -17,9 +17,9 @@ export const getQueryResults = createSelector(
   getAllResults,
   getFilter,
   (results, filter) => {
-    let features = [];
+    const features = {};
     for (const path in results) {
-      features = features.concat(matchFeatures(results[path], filter));
+      features[path] = matchFeatures(results[path], filter);
     }
     return features;
   }


### PR DESCRIPTION
- Changes the return signature for filtered results to be grouped by path.
- Updates results of the super tab to use that selector for rendering HTML.

refs: #698 