### PR TITLE
Catch common mapbook issues with nicer errors

### DIFF
--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -447,9 +447,7 @@ export function getLayer(mapSources, layer) {
     }
   }
   console.error("Cannot find layer", layer.mapSourceName, layer.layerName);
-  throw new Error(
-    `Cannot find layer ${layer.mapSourceName}/${layer.layerName}`
-  );
+  return {};
 }
 
 /** Get a layer using the internal path format "source"/"layer"
@@ -615,8 +613,7 @@ export function getLayerFromSources(mapSources, msName, layerName) {
       }
     }
   }
-
-  return null;
+  return {};
 }
 
 /** Return the list of layers that can be queried.

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -348,6 +348,13 @@ class Application {
     let mapbookXml = contents;
     if (typeof contents === "string") {
       mapbookXml = new DOMParser().parseFromString(contents, "text/xml");
+      if (mapbookXml.documentElement.nodeName === "parsererror") {
+        console.error(
+          "Could not parse mapbook!",
+          mapbookXml.documentElement.innerHTML
+        );
+        return false;
+      }
     }
 
     this.configureSelectionLayer(

--- a/src/gm3/reducers/mapSource.js
+++ b/src/gm3/reducers/mapSource.js
@@ -82,14 +82,18 @@ const reducer = createReducer(
       state,
       { payload: { mapSourceName, layerName, on } }
     ) => {
-      state[mapSourceName].layers = modifyLayer(
-        state[mapSourceName].layers,
-        layerName,
-        (layer) => {
-          layer.on = on;
-          return layer;
-        }
-      );
+      if (!state[mapSourceName]) {
+        console.error("Map source does not exist: ", mapSourceName);
+      } else {
+        state[mapSourceName].layers = modifyLayer(
+          state[mapSourceName].layers,
+          layerName,
+          (layer) => {
+            layer.on = on;
+            return layer;
+          }
+        );
+      }
     },
     [favoriteLayer]: (
       state,
@@ -104,6 +108,8 @@ const reducer = createReducer(
             return layer;
           }
         );
+      } else {
+        console.error("Map source does not exist: ", mapSourceName);
       }
     },
     [setLayerTemplate]: (


### PR DESCRIPTION
- Allow graceful failure on a bad mapsource name
- Give the user more information on the console regarding bad XML in the mapbook.