### PR TITLE
Allow the selection to be toggled off during print

### DIFF
--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -510,11 +510,18 @@ function isMapSourceActive(mapSource) {
 /** Get the list of all map-sources which have a
  *  layer that is on.
  */
-export function getActiveMapSources(mapSources, onlyPrintable = false) {
+export function getActiveMapSources(
+  mapSources,
+  onlyPrintable = false,
+  includeSelection = true
+) {
   const active = [];
   const allMaps = !onlyPrintable;
   for (const ms in mapSources) {
-    if (isMapSourceActive(mapSources[ms])) {
+    if (
+      isMapSourceActive(mapSources[ms]) &&
+      (includeSelection || ms !== "selection")
+    ) {
       if (allMaps || mapSources[ms].printable) {
         active.push(ms);
       }

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -303,9 +303,11 @@ class Map extends React.Component {
   refreshMapSources() {
     // get the list of current active map-sources
     const printOnly = this.props.printOnly === true;
+    const includeSelection = this.props.includeSelection !== false;
     const activeMapSources = mapSourceActions.getActiveMapSources(
       this.props.mapSources,
-      printOnly
+      printOnly,
+      includeSelection
     );
 
     // annoying O(n^2) iteration to see if the mapsource needs

--- a/src/gm3/components/print/printImage.js
+++ b/src/gm3/components/print/printImage.js
@@ -95,6 +95,7 @@ const PrintImage = (props) => {
         center={center}
         resolution={rez}
         printOnly={true}
+        includeSelection={props.includeSelection}
         mapRenderedCallback={() => {
           if (parentRef.current) {
             setImage(getImage(parentRef.current, [props.width, props.height]));
@@ -108,6 +109,7 @@ const PrintImage = (props) => {
 PrintImage.defaultProps = {
   width: 600,
   height: 400,
+  includeSelection: true,
 };
 
 const mapToProps = (state) => ({

--- a/src/gm3/components/print/printModal.js
+++ b/src/gm3/components/print/printModal.js
@@ -121,6 +121,7 @@ export class PrintModal extends Modal {
       layout: 0,
       resolution: 1,
       layouts: props.layouts ? props.layouts : DefaultLayouts,
+      includeSelection: "true",
     };
   }
 
@@ -550,6 +551,24 @@ export class PrintModal extends Modal {
     );
   }
 
+  /** Choose whether to include the selected layers in the output.
+   */
+  renderIncludeSelection(t) {
+    return (
+      <select
+        onChange={(evt) => {
+          this.setState({
+            includeSelection: evt.target.value,
+          });
+        }}
+        value={this.state.resolution}
+      >
+        <option value="true">{t("yes")}</option>
+        <option value="false">{t("no")}</option>
+      </select>
+    );
+  }
+
   renderBody() {
     // small set of CSS hacks to keep the print map
     //  invisible but drawn.
@@ -605,6 +624,10 @@ export class PrintModal extends Modal {
                 <label>{`${t("resolution")}:`}</label>
                 {this.renderResolutionSelect(t)}
               </p>
+              <p>
+                <label>{`${t("include-selection")}:`}</label>
+                {this.renderIncludeSelection(t)}
+              </p>
             </div>
           )}
         </Translation>
@@ -620,6 +643,7 @@ export class PrintModal extends Modal {
             width={mapSize.width}
             height={mapSize.height}
             store={this.props.store}
+            includeSelection={this.state.includeSelection === "true"}
           />
         </div>
       </div>

--- a/src/gm3/components/print/printModal.js
+++ b/src/gm3/components/print/printModal.js
@@ -561,7 +561,7 @@ export class PrintModal extends Modal {
             includeSelection: evt.target.value,
           });
         }}
-        value={this.state.resolution}
+        value={this.state.includeSelection}
       >
         <option value="true">{t("yes")}</option>
         <option value="false">{t("no")}</option>

--- a/src/gm3/lang/en.json
+++ b/src/gm3/lang/en.json
@@ -117,5 +117,8 @@
   "zoomto-results" : "Zoom to results",
   "zoomto-tip" : "Zoom to layer extents.",
   "zoom-in" : "Zoom In",
-  "zoom-out" : "Zoom Out"
+  "zoom-out" : "Zoom Out",
+  "include-selection": "Include selection",
+  "yes": "Yes",
+  "no": "No"
 }


### PR DESCRIPTION
Adds a new prop to Map and PrintImage that can turn off the rendering of the selection layer.

refs: #745