### PR TITLE
Default to enabling hash tracker on mobile

### DIFF
--- a/examples/mobile/mobile.js
+++ b/examples/mobile/mobile.js
@@ -66,6 +66,9 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
         zoom: 12
     });
 
+    const hashTracker = new gm3.trackers.HashTracker(app.store);
+    hashTracker.restore();
+
     app.registerService('identify', IdentifyService);
     app.registerAction('findme', FindMeAction);
 
@@ -98,4 +101,6 @@ app.loadMapbook({url: 'mapbook.xml'}).then(function() {
     });
 
     changeTab('map');
+
+    hashTracker.startTracking();
 });


### PR DESCRIPTION
This will display the hash in the url for users by default, making it easier to both swap and share locations from mobile.

refs: #886 