### PR TITLE
Restore "new-results" ui hint

### DIFF
--- a/src/gm3/actions/query.js
+++ b/src/gm3/actions/query.js
@@ -147,6 +147,7 @@ export const runQuery = createAsyncThunk(
       allResults.forEach((result) => {
         results[result.layer] = result.features;
       });
+      dispatch(setUiHint("new-results"));
       return results;
     });
   }


### PR DESCRIPTION
Fixes mobile issue with not jumping to the reuslts tab.