### PR TITLE
Hack to fix queries with QGIS WFS Server

### DIFF
--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -214,6 +214,21 @@ function mapServerToWFS(msXml, conf) {
   return wfsConf;
 }
 
+/** Convert a type='qgis-wfs' layer into type='wfs'
+ *  style layer.
+ *
+ *  @param mxXml The MapSource XML
+ *  @param conf  Application configuration object.
+ *
+ * @returns Object defining the WFS service.
+ */
+function QGISToWFS(msXml, conf) {
+  return {
+    type: 'wfs',
+    wgs84Hack: true
+  };
+}
+
 /** Add a map-source from XML
  *
  */
@@ -261,6 +276,8 @@ export function addFromXml(xml, config) {
     Object.assign(mapSource, mapServerToWMS(xml, config));
   } else if (mapSource.type === "mapserver-wfs") {
     Object.assign(mapSource, mapServerToWFS(xml, config));
+  } else if (mapSource.type === "qgis-wfs") {
+    Object.assign(mapSource, QGISToWFS(xml, config));
   }
 
   // parse the optional float attributes

--- a/src/gm3/components/map/layers/wfs.js
+++ b/src/gm3/components/map/layers/wfs.js
@@ -99,7 +99,7 @@ export function buildWfsQuery(
   // the internal storage mechanism requires features
   //  returned from the query be stored in 4326 and then
   //  reprojected on render.
-  let queryProjection = mapProjection;
+  let queryProjection = new proj.get(mapProjection);
   if (mapSource.wgs84Hack) {
     queryProjection = new proj.get("EPSG:4326");
   }
@@ -137,8 +137,10 @@ export function buildWfsQuery(
   // the OL formatter requires that the typename and the schema be
   //  broken apart in order to properly format the request.
   const typename = getTypeName(mapSource);
-
-  const typeParts = typename.split(":");
+  let typeParts = typename.split(":");
+  if (typeParts.length === 1) {
+    typeParts = ["", typeParts[0]];
+  }
   const formatOptions = {
     srsName: queryProjection.getCode(),
     featurePrefix: typeParts[0],


### PR DESCRIPTION
 - QGIS Typename does not have a schema/namespace
 - QGIS needs wgs84Hack (or more likely to be told the query coordinates are in 3857)
 - The non-wgs84Hack code path had a type error calling getCode() on a string.

This more or less makes things work with a `<mapsource type='qgis-wfs'>`.  But I'm not even pretending this is the right way to go about this.

ref: #901