### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "reqwest": "^2.0.5",
         "usng-map-collar": "^1.0.1",
         "usng-tools-js": "git+https://github.com/klassenjs/usng-tools-js.git",
-        "uuid": "^3.2.1",
+        "uuid": "^11.1.0",
         "webpack": "^5.70.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.2",
@@ -15617,13 +15617,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -28159,9 +28163,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "reqwest": "^2.0.5",
     "usng-map-collar": "^1.0.1",
     "usng-tools-js": "git+https://github.com/klassenjs/usng-tools-js.git",
-    "uuid": "^3.2.1",
+    "uuid": "^11.1.0",
     "webpack": "^5.70.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.2",

--- a/src/gm3/actions/catalog.js
+++ b/src/gm3/actions/catalog.js
@@ -26,7 +26,7 @@
  *
  */
 
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import { createAction } from "@reduxjs/toolkit";
 
 import { parseBoolean, getTagContents } from "../util";
@@ -267,7 +267,7 @@ export function parseCatalog(store, catalogXml) {
   const elements = catalogXml.getElementsByTagName("*");
   for (let i = 0, ii = elements.length; i < ii; i++) {
     const e = elements[i];
-    e.setAttribute("uuid", uuid.v4());
+    e.setAttribute("uuid", uuid());
   }
 
   return subtreeActions(store, null, catalogXml);

--- a/src/gm3/components/map/attribution-display.js
+++ b/src/gm3/components/map/attribution-display.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 
 class AttributionDisplay extends React.Component {
   render() {

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -27,7 +27,7 @@ import { connect } from "react-redux";
 import ReactResizeDetector from "react-resize-detector";
 import { withTranslation } from "react-i18next";
 
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 
 import * as mapSourceActions from "../../actions/mapSource";
 import * as mapActions from "../../actions/map";
@@ -252,7 +252,7 @@ class Map extends React.Component {
         const wmsSrc = this.olLayers[mapSource.name].getSource();
         const params = wmsSrc.getParams();
         // ".ck" = "cache killer"
-        params[".ck"] = uuid.v4();
+        params[".ck"] = uuid();
         wmsSrc.updateParams(params);
         break;
       default:

--- a/src/gm3/components/serviceInputs/text.js
+++ b/src/gm3/components/serviceInputs/text.js
@@ -24,9 +24,9 @@
 
 import React, { Component } from "react";
 
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 
-export const getId = () => uuid.v4();
+export const getId = () => uuid();
 
 export default class TextInput extends Component {
   constructor(props) {

--- a/src/gm3/reducers/catalog.js
+++ b/src/gm3/reducers/catalog.js
@@ -27,7 +27,7 @@
  */
 
 import { createReducer } from "@reduxjs/toolkit";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import {
   addLayer,
   addGroup,
@@ -38,7 +38,7 @@ import {
 
 const DEFAULT_CATALOG = {
   root: {
-    id: uuid.v4(),
+    id: uuid(),
     children: [],
   },
 };

--- a/src/gm3/reducers/mapSource.js
+++ b/src/gm3/reducers/mapSource.js
@@ -26,7 +26,7 @@
  *
  */
 
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import { createReducer } from "@reduxjs/toolkit";
 import { changeFeatures, filterFeatures } from "../util";
 


### PR DESCRIPTION
`npm install`:
```
npm warn deprecated source-map-resolve@0.6.0: See https://github.com/lydell/source-map-resolve#deprecated
npm warn deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm warn deprecated uuid@3.3.3: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm warn deprecated core-js@2.6.11: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
```

`install_test_deps.sh`:
```
npm warn deprecated npmlog@5.0.1: This package is no longer supported.
npm warn deprecated are-we-there-yet@2.0.0: This package is no longer supported.
npm warn deprecated gauge@3.0.2: This package is no longer supported.

```