### PR TITLE
Use HTML5+CSS components for the catalog

### DIFF
--- a/src/gm3/components/catalog/group.js
+++ b/src/gm3/components/catalog/group.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Dan "Ducky" Little
+ * Copyright (c) 2016-2017,2025 Dan "Ducky" Little
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,18 +29,23 @@ import MetadataTool from "./tools/metadata";
 const CatalogGroup = ({ group, onExpand, children }) => {
   const { t } = useTranslation();
   const classes = "group " + (!!group.expand ? "gm-expand" : "gm-collapse");
-  const iconClasses = "folder icon " + (!!group.expand ? "open" : "");
-
   return (
     <div key={group.id} className={classes}>
-      <div onClick={onExpand} className="group-label" title={t(group.tip)}>
-        <i className={iconClasses}></i>
-        {t(group.label)}{" "}
-        {!group.metadata_url ? (
-          false
-        ) : (
-          <MetadataTool href={group.metadata_url} />
-        )}
+      <div className="group-label" title={t(group.tip)}>
+        <input
+          className="group-toggle icon"
+          type="checkbox"
+          checked={!!group.expand}
+          onChange={onExpand}
+        />
+        <span onClick={onExpand}>
+          {t(group.label)}{" "}
+          {!group.metadata_url ? (
+            false
+          ) : (
+            <MetadataTool href={group.metadata_url} />
+          )}
+        </span>
       </div>
       <div className="children">{children}</div>
     </div>

--- a/src/gm3/components/catalog/layer-checkbox.js
+++ b/src/gm3/components/catalog/layer-checkbox.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Dan "Ducky" Little
+ * Copyright (c) 2016-2017,2025 Dan "Ducky" Little
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 
 import React from "react";
 import { connect } from "react-redux";
+import { useTranslation } from "react-i18next";
 
 import { setLayerVisibility } from "../../actions/mapSource";
 import { isLayerOn } from "../../util";
@@ -76,24 +77,23 @@ const getNeighboringLayers = (catalog, layer) => {
   return allSrcs;
 };
 
-const LayerCheckbox = (props) => {
-  let classes = "checkbox icon";
-  if (props.layer.exclusive === true) {
-    classes = "radio icon";
-  }
-  if (props.on) {
-    classes += " on";
-  }
-
+const LayerCheckbox = ({ catalog, layer, on, onChange }) => {
+  const isExclusive = layer.exclusive === true;
+  const { t } = useTranslation();
+  const label = t(on ? "hide-layer" : "show-layer", { label: layer.label });
   return (
-    <i
-      className={classes}
-      onClick={() => {
-        if (props.layer.exclusive === true) {
-          const neighbors = getNeighboringLayers(props.catalog, props.layer);
-          props.onChange(!props.on, neighbors);
+    <input
+      className="layer-toggle icon"
+      type={isExclusive ? "radio" : "checkbox"}
+      checked={on}
+      aria-label={label}
+      title={label}
+      onChange={() => {
+        if (isExclusive) {
+          const neighbors = getNeighboringLayers(catalog, layer);
+          onChange(!on, neighbors);
         } else {
-          props.onChange(!props.on);
+          onChange(!on);
         }
       }}
     />

--- a/src/gm3/components/catalog/layer.js
+++ b/src/gm3/components/catalog/layer.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017 Dan 'Ducky' Little
+ * Copyright (c) 2016-2017, 2025 Dan 'Ducky' Little
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the 'Software'), to deal

--- a/src/gm3/lang/en.json
+++ b/src/gm3/lang/en.json
@@ -120,5 +120,7 @@
   "zoom-out" : "Zoom Out",
   "include-selection": "Include selection",
   "yes": "Yes",
-  "no": "No"
+  "no": "No",
+  "show-layer": "Show layer {{label}}",
+  "hide-layer": "Hide layer {{label}}"
 }

--- a/src/gm3/lang/es.json
+++ b/src/gm3/lang/es.json
@@ -111,5 +111,7 @@
   "zoomto-results" : "Zoom a la seleccion",
   "zoomto-tip" : "Zoom a la capa",
   "zoom-in" : "Acercar la imagen",
-  "zoom-out" : "Alejar la imagen"
+  "zoom-out" : "Alejar la imagen",
+  "show-layer": "Mostrar capa {{label}}",
+  "hide-layer": "Ocultar capa {{label}}"
 }

--- a/src/gm3/lang/fr.json
+++ b/src/gm3/lang/fr.json
@@ -108,5 +108,7 @@
   "with-buffer" : "Avec tampon",
   "zoomto-extent" : "Zoomer sur l'étendue...",
   "zoomto-results" : "Zoomer sur le résultat",
-  "zoomto-tip" : "Zoomer sur la couche."
+  "zoomto-tip" : "Zoomer sur la couche.",
+  "show-layer": "Afficher le calque {{label}}",
+  "hide-layer": "Masquer le calque {{label}}"
 }

--- a/src/gm3/lang/it.json
+++ b/src/gm3/lang/it.json
@@ -105,5 +105,7 @@
   "with-buffer" : "Con buffer",
   "zoomto-extent" : "Zoom all'estensione...",
   "zoomto-results" : "Zoom sui risultati",
-  "zoomto-tip" : "Zoom all'estensione del layer."
+  "zoomto-tip" : "Zoom all'estensione del layer.",
+  "show-layer": "Mostra livello {{label}}",
+  "hide-layer": "Nascondi livello {{label}}"
 }

--- a/src/gm3/lang/pt-br.json
+++ b/src/gm3/lang/pt-br.json
@@ -108,6 +108,8 @@
     "with-buffer" : "Com buffer",
     "zoomto-extent" : "Zoom para ...",
     "zoomto-results" : "Zoom para resultados",
-    "zoomto-tip" : "Zoom para toda a camada."
+    "zoomto-tip" : "Zoom para toda a camada.",
+    "show-layer": "Mostrar camada {{label}}",
+    "hide-layer": "Ocultar camada {{label}}"
   }
 

--- a/src/less/catalog.less
+++ b/src/less/catalog.less
@@ -27,12 +27,28 @@
 .group {
     .group {
         padding-left: 20px;
-
     }
 
     .group-label {
-        font-weight: bold;
-        cursor: pointer;
+      font-weight: bold;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+
+        input[type="checkbox"] {
+          border: none;
+
+          &::before {
+            content: "\25B8";
+            content: "\2b9e";
+            transition: 120ms transform ease-in-out;
+            transform: rotate(0deg);
+          }
+
+          &:checked::before {
+            transform: rotate(90deg);
+          }
+        }
 
         &:hover {
             background-color: #eee;
@@ -42,22 +58,20 @@
     .layer {
         padding-left: 20px;
     }
-}
 
-.group.gm-collapse {
-    .children {
+    &.gm-collapse {
+      .children {
         max-height: 0 !important;
         overflow: hidden;
-        /*display: none !important;*/
         transition: max-height 0.5s ease-in;
+      }
     }
-}
 
-
-.group.gm-expand {
-    .children {
+    &.gm-expand {
+      .children {
         max-height: 2000px;
         transition: max-height 0.5s ease-in;
+      }
     }
 }
 
@@ -65,6 +79,39 @@
 @checkbox-margin: 2px;
 
 .layer {
+    input[type="radio"],input[type="checkbox"] {
+      border-radius: 50%;
+      &::before {
+        content: "";
+        width: 0.65em;
+        height: 0.65em;
+        border-radius: 50%;
+        transform: scale(0);
+        transition: 120ms transform ease-in-out;
+        box-shadow: inset 1em 1em currentColor;
+      }
+
+      &:checked::before {
+        transform: scale(1);
+      }
+    }
+
+    input[type="checkbox"] {
+      border-radius: 10%;
+
+      &::before {
+        content: "\2714";
+        width: 0.5em;
+        height: 0.5em;
+        box-shadow: none;
+      }
+      &:checked::before {
+        transform: scale(1) translateY(-0.5em) translateX(-0.125em);
+      }
+    }
+
+    /* now use nicely scaled and color controllable css */
+
     .layer-label {
         cursor: pointer;
 
@@ -135,6 +182,22 @@
 }
 
 .catalog {
+    /* suppress browser rendering of checkboxes and radio buttons */
+    input[type="radio"],input[type="checkbox"] {
+      appearance: none;
+      display: inline-grid;
+      place-content: center;
+
+      font: inherit;
+      color: currentColor;
+
+      width: 1.0em;
+      height: 1.0em;
+      border: 0.15em solid currentColor;
+      margin: 0.5em;
+      margin-left: 0;
+    }
+
     .searchbox {
         position: absolute;
         width: 100%;

--- a/tests/gm3/components/catalog.test.js
+++ b/tests/gm3/components/catalog.test.js
@@ -125,9 +125,9 @@ describe("Catalog component tests", () => {
   });
 
   it("toggles the group state", function () {
-    fireEvent.click(catalog.querySelector(".group-label"));
+    fireEvent.click(catalog.querySelector(".group-toggle"));
     expect(catalog.querySelector(".gm-expand")).not.toBeNull();
-    fireEvent.click(catalog.querySelector(".group-label"));
+    fireEvent.click(catalog.querySelector(".group-toggle"));
     expect(catalog.querySelector(".gm-collapse")).not.toBeNull();
   });
 
@@ -136,7 +136,7 @@ describe("Catalog component tests", () => {
   });
 
   it("toggles layer visibility", function () {
-    fireEvent.click(catalog.querySelector(".checkbox"));
+    fireEvent.click(catalog.querySelector(".layer-toggle"));
     // the layer is on by default
     expect(store.getState().mapSources.test.layers[0].on).toBe(false);
   });


### PR DESCRIPTION
- Moves icon based controls to `<input>`
- Updates styling to support the move to `<input>`
- Added ARIA friendly labels for additional accessibility (includes translations)