### PR TITLE
Draft: Add GeoParquet support to the mapsource types

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -87,6 +87,20 @@
         </layer>
     </map-source>
 
+    <map-source name="parquet-parcels" type="geoparquet">
+      <url>./parcels.geoparquet</url>
+      <layer name="default" title="Parquet Parcels">
+        <style><![CDATA[
+          {
+            "line-color": "#ff0000",
+            "line-width": 3
+          }
+        ]]></style>
+
+        <template name="identify" auto="true" />
+      </layer>
+    </map-source>
+
     <map-source name="vector-parcels" type="mapserver-wfs">
         <file>demo/parcels/parcels.map</file>
         <param name="typename" value="ms:parcels"/>
@@ -492,6 +506,9 @@
 
                 <layer title="Vector Parcels" src="vector-parcels/parcels">
                     <metadata>https://raw.githubusercontent.com/geomoose/gm3-demo-data/main/demo/parcels/LICENSE</metadata>
+                </layer>
+
+                <layer title="GeoParquet Parcels" src="parquet-parcels/default">
                 </layer>
 
                 <layer src="parcels/parcels" metadata="true" legend-toggle="true" tip="Sample land records" refresh="10">

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -98,6 +98,17 @@
         ]]></style>
 
         <template name="identify" auto="true" />
+
+        <template name="select-header"><![CDATA[
+        <div class="info">
+        Parcel selection results are shown in the results grid.
+        </div>
+        ]]></template>
+
+        <template name="select-grid-columns" src="./templates/parcel-columns.json" />
+        <template name="select-grid-row" src="./templates/parcel-row.html" />
+
+
       </layer>
     </map-source>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@testing-library/react": "^13.3.0",
         "@turf/boolean-intersects": "^6.5.0",
         "babel-jest": "^27.3.1",
+        "geoparquet": "^0.5.0",
+        "hyparquet-compressors": "^1.1.1",
         "jest-environment-jsdom": "^30.1.1",
         "prop-types": "^15.8.1",
         "react-virtuoso": "^2.16.6",
@@ -9403,6 +9405,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9440,6 +9448,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/geoparquet": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/geoparquet/-/geoparquet-0.5.0.tgz",
+      "integrity": "sha512-hsBXHKrP/q9Y9ZNJvmYEXMDSI9mG+P6Rhwxeh9yNMjG55InbuLqLhyxXcgAJzo1L0KlGTfQbik4GJZr09BaIIg==",
+      "license": "MIT",
+      "dependencies": {
+        "hyparquet": "1.17.3"
       }
     },
     "node_modules/geotiff": {
@@ -9911,6 +9928,22 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyparquet": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.17.3.tgz",
+      "integrity": "sha512-fUvAiVnJ+H49wk7/XE6jCqRx6+sVOP5eDoYGp5myeLCWucT/ZgOAhrvPZHM5CRAy6oT8B0BH62Vyoih05KEv9g==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "license": "MIT",
+      "dependencies": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -9920,6 +9953,12 @@
       "engines": {
         "node": ">=10.18"
       }
+    },
+    "node_modules/hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
+      "license": "MIT"
     },
     "node_modules/i18next": {
       "version": "19.4.4",
@@ -23616,6 +23655,11 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
+    "fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA=="
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -23646,6 +23690,14 @@
             "@turf/helpers": "^6.5.0"
           }
         }
+      }
+    },
+    "geoparquet": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/geoparquet/-/geoparquet-0.5.0.tgz",
+      "integrity": "sha512-hsBXHKrP/q9Y9ZNJvmYEXMDSI9mG+P6Rhwxeh9yNMjG55InbuLqLhyxXcgAJzo1L0KlGTfQbik4GJZr09BaIIg==",
+      "requires": {
+        "hyparquet": "1.17.3"
       }
     },
     "geotiff": {
@@ -23989,11 +24041,30 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
+    "hyparquet": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.17.3.tgz",
+      "integrity": "sha512-fUvAiVnJ+H49wk7/XE6jCqRx6+sVOP5eDoYGp5myeLCWucT/ZgOAhrvPZHM5CRAy6oT8B0BH62Vyoih05KEv9g=="
+    },
+    "hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "requires": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
     "hyperdyperid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
       "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
       "dev": true
+    },
+    "hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA=="
     },
     "i18next": {
       "version": "19.4.4",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "@testing-library/react": "^13.3.0",
     "@turf/boolean-intersects": "^6.5.0",
     "babel-jest": "^27.3.1",
+    "geoparquet": "^0.5.0",
+    "hyparquet-compressors": "^1.1.1",
     "jest-environment-jsdom": "^30.1.1",
     "prop-types": "^15.8.1",
     "react-virtuoso": "^2.16.6",

--- a/src/gm3/actions/mapSource.js
+++ b/src/gm3/actions/mapSource.js
@@ -556,6 +556,7 @@ function isQueryable(mapSource) {
     case "ags-vector":
     case "geojson":
     case "vector":
+    case "geoparquet":
       return true;
     default:
       return false;
@@ -575,6 +576,7 @@ function isSelectable(mapSource, layer) {
     case "wfs":
     case "vector":
     case "ags-vector":
+    case "geoparquet":
       return layer.selectable === true;
     default:
       return false;

--- a/src/gm3/actions/query.js
+++ b/src/gm3/actions/query.js
@@ -134,6 +134,7 @@ export const runQuery = createAsyncThunk(
         case "ags-vector":
           return agsFeatureQuery(layer, state.map, mapSource, queryDef);
         case "geojson":
+        case "geoparquet":
         case "vector":
           return vectorFeatureQuery(layer, state.map, mapSource, queryDef);
         default:

--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -186,12 +186,19 @@ class Map extends React.Component {
       case "usng":
         usngLayer.updateLayer(this.map, olLayer, mapSource);
         break;
+      case "geoparquet":
       case "blank":
         // this is a non-op, blank will be blank for all time.
         break;
       default:
         console.info("Unhandled map-source type: " + mapSource.type);
     }
+  }
+
+  backloadFeatures(mapSource) {
+    return (features) => {
+      this.props.setFeatures(mapSource.name, features);
+    };
   }
 
   /** Create an OL Layers based on a GM MapSource definition
@@ -215,6 +222,12 @@ class Map extends React.Component {
       case "ags-vector":
       case "geojson":
         return vectorLayer.createLayer(mapSource);
+      case "geoparquet":
+        return vectorLayer.createLayer(
+          mapSource,
+          undefined,
+          this.backloadFeatures(mapSource)
+        );
       case "bing":
         return bingLayer.createLayer(mapSource);
       case "usng":
@@ -591,7 +604,8 @@ class Map extends React.Component {
 
         if (
           isSelection ||
-          ["wfs", "vector", "geojson"].indexOf(mapSource.type) >= 0
+          ["wfs", "vector", "geojson", "geoparquet"].indexOf(mapSource.type) >=
+            0
         ) {
           const layers = isSelection
             ? [this.selectionLayer]

--- a/src/gm3/query/vector.js
+++ b/src/gm3/query/vector.js
@@ -1,4 +1,3 @@
-// import { intersects as bboxIntersects } from 'ol/extent';
 import intersects from "@turf/boolean-intersects";
 
 export const vectorFeatureQuery = (layer, mapState, mapSource, query) => {


### PR DESCRIPTION
This is a fairly raw version of the parquet support. It loads the entire parquet file, on the main thread.

Missing from the commit is the demo parcels file.