### PR TITLE
Fix for catalog group icons and title clicks

### DIFF
--- a/src/gm3/components/catalog/group.js
+++ b/src/gm3/components/catalog/group.js
@@ -31,14 +31,14 @@ const CatalogGroup = ({ group, onExpand, children }) => {
   const classes = "group " + (!!group.expand ? "gm-expand" : "gm-collapse");
   return (
     <div key={group.id} className={classes}>
-      <div className="group-label" title={t(group.tip)}>
+      <div className="group-label" title={t(group.tip)} onClick={onExpand}>
         <input
           className="group-toggle icon"
           type="checkbox"
           checked={!!group.expand}
           onChange={onExpand}
         />
-        <span onClick={onExpand}>
+        <span>
           {t(group.label)}{" "}
           {!group.metadata_url ? (
             false

--- a/src/less/catalog.less
+++ b/src/less/catalog.less
@@ -36,16 +36,24 @@
       align-items: center;
 
       input[type="checkbox"] {
+        /* force fontawesome for the checkbox */
+        .fa;
         border: none;
 
         &::before {
-          content: "\2b9e";
-          transition: 120ms transform ease-in-out;
-          transform: rotate(0deg) translateY(-0.5em) translateX(-0.125em);
+          display: inline-block;
+          content: @fa-var-chevron-right;
+          transform: translateX(50%) translateY(0%);
         }
 
-        &:checked::before {
-          transform: rotate(90deg) translateY(-0.5em) translateX(-0.125em);
+        transition: 120ms transform ease-in-out;
+        transform: rotate(0deg);
+
+        &:checked {
+          transform: rotate(90deg);
+          &::before {
+            transform: translateX(50%) translateY(-50%);
+          }
         }
       }
 


### PR DESCRIPTION
1. Moves the `onClick` event to the entire catalog title `<div/>`
2. Changes to for Font-Awesome icon to prevent font differences amount platforms.

refs: #930, #925