### PR TITLE
Add a new service (open-new) and example usage

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -73,6 +73,10 @@ app.loadMapbook().then(function() {
         def: '+proj=utm +zone=15 +ellps=GRS80 +datum=NAD83 +units=m +no_defs'
     });
 
+    app.registerService('open-streetview', OpenNewService, {
+      url: 'https://www.bing.com/maps?cp=${lat}%7E${lon}&lvl=18.5&style=3d',
+    });
+
     app.registerService('identify', IdentifyService);
 
     app.registerService('search-runways', SearchService, {

--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -74,7 +74,7 @@ app.loadMapbook().then(function() {
     });
 
     app.registerService('open-streetview', OpenNewService, {
-      url: 'https://www.bing.com/maps?cp=${lat}%7E${lon}&lvl=18.5&style=3d',
+      url: 'https://www.bing.com/maps?cp={{lat}}%7E{{lon}}&lvl=18.5&style=3d',
     });
 
     app.registerService('identify', IdentifyService);

--- a/examples/desktop/index.html
+++ b/examples/desktop/index.html
@@ -74,6 +74,7 @@
 
     <script type="text/javascript" src="config.js"></script>
     <script type="text/javascript" src="../geomoose/dist/geomoose.min.js"></script>
+    <script type="text/javascript" src="../geomoose/dist/services/open-new.js"></script>
     <script type="text/javascript" src="../geomoose/dist/services/identify.js"></script>
     <script type="text/javascript" src="../geomoose/dist/services/search.js"></script>
     <script type="text/javascript" src="../geomoose/dist/services/select.js"></script>

--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -562,5 +562,6 @@
         <tool name="findme" title="Find Me" type="action"/>
         <tool name="reload" title="Start Over" type="action"/>
         <tool name="bookmark" title="Bookmark" type="action"/>
+        <tool name="open-streetview" title="3D View" type="service" />
     </toolbar>
 </mapbook>

--- a/src/gm3/application.js
+++ b/src/gm3/application.js
@@ -971,6 +971,13 @@ class Application {
   }
 
   /**
+   * Project a point from web mercator to lon/lat decimal degrees
+   */
+  toLonLat(x, y) {
+    return Proj.transform([x, y], "EPSG:3857", "EPSG:4326");
+  }
+
+  /**
    * Project a bounding box to web mercator.
    */
   bboxToMeters(west, south, east, north) {

--- a/src/gm3/components/serviceManager/results.js
+++ b/src/gm3/components/serviceManager/results.js
@@ -141,34 +141,36 @@ export const QueryResults = ({
       )}
 
       <div className="results-info-counts">
-        {resultsConfig.showLayerCount && (
+        {showHeader && resultsConfig.showLayerCount && (
           <div className="results-info-item layers-count">
             <div className="label">{t("layers")}</div>
             <div className="value">{layerCount}</div>
           </div>
         )}
-        {resultsConfig.showFeatureCount && (
+        {showHeader && resultsConfig.showFeatureCount && (
           <div className="results-info-item features-count">
             <div className="label">{t("features")}</div>
             <div className="value">{featureCount}</div>
           </div>
         )}
 
-        {resultsConfig.showFeatureCount && featureCount < allFeatureCount && (
-          <div className="results-info-item filtered-features">
-            {t(
-              "The search returned {{allFeatureCount}} results. {{missing}} results are filtered out, and the remaining {{featureCount}} results are displayed.",
-              {
-                allFeatureCount: allFeatureCount,
-                missing: allFeatureCount - featureCount,
-                featureCount: featureCount,
-              }
-            )}
-          </div>
-        )}
+        {showHeader &&
+          resultsConfig.showFeatureCount &&
+          featureCount < allFeatureCount && (
+            <div className="results-info-item filtered-features">
+              {t(
+                "The search returned {{allFeatureCount}} results. {{missing}} results are filtered out, and the remaining {{featureCount}} results are displayed.",
+                {
+                  allFeatureCount: allFeatureCount,
+                  missing: allFeatureCount - featureCount,
+                  featureCount: featureCount,
+                }
+              )}
+            </div>
+          )}
       </div>
 
-      {allFeatureCount === 0 && (
+      {showHeader && allFeatureCount === 0 && (
         <div className="info-box">
           {t(
             "Your query did not return any results. Adjust your selection area or filters and try again."

--- a/src/services/open-new.js
+++ b/src/services/open-new.js
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Dan "Ducky" Little
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/** Open New Service.
+ *
+ * When a user clicks on a map, open a new window at that coordinate!
+ *
+ */
+function OpenNewService(Application, options) {
+  /** Define the title of the service. */
+  this.title = options.title ? options.title : "Jump to external service";
+
+  /** Title to show at the top of the results. */
+  this.resultsTitle = options.resultsTitle
+    ? options.resultsTitle
+    : "Open Results";
+
+  this.showGrid = false;
+
+  this.showHeader = false;
+
+  /** Name will be set by the application when the service is registered. */
+  this.name = "";
+
+  /** Limit the number of selection tools available */
+  this.tools = { Point: true, default: "Point" };
+
+  /** autoGo = true instructs the service to query whenever
+   *                the geometry has changed.
+   */
+  this.autoGo = true;
+
+  /** keepAlive = true will keep the service in 'query mode'
+   *                   in the background, until it is explictly turned off.
+   */
+  this.keepAlive = true;
+
+  /** User input fields, there are none for identify */
+  this.fields = [];
+
+  this.getUrl = function (selection) {
+    const [x, y] = selection[0].geometry.coordinates;
+    const [lon, lat] = Application.toLonLat(x, y);
+    // eslint-disable-next-line no-template-curly-in-string
+    return options.url.replace("${lat}", lat).replace("${lon}", lon);
+  };
+
+  /** This function is called everytime there is an identify query.
+   *
+   *  @param selection contains a GeoJSON feature describing the
+   *                   geography to be used for the query.
+   *
+   *  @param fields    is an array containing any user-input
+   *                   given to the service.
+   */
+  this.query = function (selection, fields) {
+    window.open(this.getUrl(selection));
+    Application.dispatchQuery(this.name, selection, [], [], []);
+  };
+
+  /** resultsAsHtml is the function used to populate the Service Tab
+   *                after the service has finished querying.
+   */
+  this.resultsAsHtml = function (queryId, query) {
+    const html = `
+      <div>
+        <a target="_blank" href="${this.getUrl(
+          query.selection
+        )}">Opened</a> in a new tab.
+      </div>
+    `;
+    return html;
+  };
+}
+
+if (typeof module !== "undefined") {
+  module.exports = OpenNewService;
+}

--- a/src/services/open-new.js
+++ b/src/services/open-new.js
@@ -62,8 +62,7 @@ function OpenNewService(Application, options) {
   this.getUrl = function (selection) {
     const [x, y] = selection[0].geometry.coordinates;
     const [lon, lat] = Application.toLonLat(x, y);
-    // eslint-disable-next-line no-template-curly-in-string
-    return options.url.replace("${lat}", lat).replace("${lon}", lon);
+    return options.url.replace("{{lat}}", lat).replace("{{lon}}", lon);
   };
 
   /** This function is called everytime there is an identify query.


### PR DESCRIPTION
Add a new service intended to open a new window based on a URL template.

- Add a new service which can open a new window.
- Adds an example to the desktop app.
- Exports a reprojection function to convert mercator to lon-lat