### PR TITLE
Fix tabindex -> tabIndex in layer-label.js

### DIFF
--- a/src/gm3/components/catalog/layer-label.js
+++ b/src/gm3/components/catalog/layer-label.js
@@ -40,7 +40,7 @@ const LayerLabel = ({ layer, on, catalog, onChange }) => {
   }, [onChange, on, catalog]);
 
   return (
-    <MinimalButton tabindex={-1} title={title} onClick={handleClick}>
+    <MinimalButton tabIndex={-1} title={title} onClick={handleClick}>
       {layer.label}
     </MinimalButton>
   );


### PR DESCRIPTION
I'm not sure if this is proper, but it fixes this error/warning in `npm test`:

```
console.error
      Warning: Invalid DOM property `tabindex`. Did you mean `tabIndex`?
          at button
          at children (src/gm3/components/MinimalButton.js:29:26)
          at layer (src/gm3/components/catalog/layer-label.js:36:23)
          at ConnectFunction (node_modules/react-redux/lib/components/connect.js:246:87)
          at div
          at div
          at layer (src/gm3/components/catalog/layer.js:91:32)
          at div
          at div
          at group (src/gm3/components/catalog/group.js:29:25)
          at div
          at Provider (node_modules/react-redux/lib/components/Provider.js:19:3)
          at Catalog (src/gm3/components/catalog/index.js:93:5)
          at ConnectFunction (node_modules/react-redux/lib/components/connect.js:246:87)
          at div

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at validateProperty$1 (node_modules/react-dom/cjs/react-dom.development.js:3749:9)
      at warnUnknownProperties (node_modules/react-dom/cjs/react-dom.development.js:3803:21)
      at validateProperties$2 (node_modules/react-dom/cjs/react-dom.development.js:3827:3)
      at validatePropertiesInDevelopment (node_modules/react-dom/cjs/react-dom.development.js:9541:5)
      at setInitialProperties (node_modules/react-dom/cjs/react-dom.development.js:9830:5)
      at finalizeInitialChildren (node_modules/react-dom/cjs/react-dom.development.js:10950:3)
```