### PR TITLE
added keyboard navigation to map

### DIFF
--- a/src/gm3/components/map/index.js
+++ b/src/gm3/components/map/index.js
@@ -837,6 +837,8 @@ class Map extends React.Component {
 
     return (
       <div
+        role="application"
+        tabIndex="0"
         className="map"
         ref={(self) => {
           this.mapDiv = self;


### PR DESCRIPTION
Currently map navigation works if the user navigates to essentially any element within the map (the +/- buttons, the OpenStreetMap citation), which doesn't make it obvious to the user that navigation works.

This allows the map to receive keyboard focus, which allows users then navigate the map with the keyboard. It also assigns the map the application role, which allows map navigation to work by default with the screen reader I was testing.

I do think an aria-label should also be assigned (I added it in the same location as the tabIndex when I was testing, and it worked). However, I feel like that's something that site admin's should be able to configure for the site themselves, or at the very least should respect the site's language settings, which I wasn't sure how to do. Perhaps by adding const { t } = useTranslation(); as well as aria-label={t("map-label")} with map-label corresponding to new entries in the language json files?