### PR TITLE
Switch GitHub actions to use pinned SHA

### DIFF
--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -22,6 +22,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@master
+        uses: erclu/check-crlf@c77fda0a97ea8944aba5f72796b9e937e7d1611c # master
         with: # ignore directories containing *.pdf and *.tab
           exclude: 

--- a/.github/workflows/irc_notify.yml
+++ b/.github/workflows/irc_notify.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'geomoose/gm3'
     steps:
       - name: irc push
-        uses: rectalogic/notify-irc@v2
+        uses: rectalogic/notify-irc@768ca068754bd0a8e2d682c111c858679f790560 # v2
         if: github.event_name == 'push'
         with:
           channel: "#geomoose"
@@ -26,7 +26,7 @@ jobs:
             ${{ github.actor }} pushed ${{ github.event.ref }} ${{ github.event.compare }}
             ${{ join(github.event.commits.*.message) }}
       - name: irc pull request
-        uses: rectalogic/notify-irc@v2
+        uses: rectalogic/notify-irc@768ca068754bd0a8e2d682c111c858679f790560 # v2
         if: github.event_name == 'pull_request'
         with:
           channel: "#geomoose"
@@ -36,7 +36,7 @@ jobs:
             ${{ github.actor }} ${{ github.event.action }} PR ${{ github.event.pull_request.html_url }}
             ${{ github.event.pull_request.title }}
       - name: irc tag created
-        uses: rectalogic/notify-irc@v2
+        uses: rectalogic/notify-irc@768ca068754bd0a8e2d682c111c858679f790560 # v2
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         with:
           channel: "#geomoose"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,11 @@ jobs:
       fail-fast: true
       matrix:
         platform: [ 'ubuntu-24.04' ]
-        node-version: [ '22.x' ]
+        node-version: [ '24.x' ]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Branches (and even tags) can change to run modified code that can leak credentials and API keys.  This is apparently happening in the wild.

https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning