### PR TITLE
fix: Drop use of vintage uuid module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,7 @@ module.exports = {
     moduleDirectories: ["./src", "./node_modules"],
     setupFiles: ["./tests/setup.js"],
     testEnvironment: "jsdom",
+    moduleNameMapper: {
+      "^@gm3/(.*)$": "<rootDir>/src/gm3/$1",
+    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,7 @@
         "redux": "^4.2.0",
         "reqwest": "^2.0.5",
         "usng-map-collar": "^1.0.1",
-        "usng-tools-js": "git+https://github.com/klassenjs/usng-tools-js.git",
-        "uuid": "^11.1.0"
+        "usng-tools-js": "git+https://github.com/klassenjs/usng-tools-js.git"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.0",
@@ -15667,19 +15666,6 @@
         "base64-arraybuffer": "^1.0.2"
       }
     },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -27977,11 +27963,6 @@
       "requires": {
         "base64-arraybuffer": "^1.0.2"
       }
-    },
-    "uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
     "redux": "^4.2.0",
     "reqwest": "^2.0.5",
     "usng-map-collar": "^1.0.1",
-    "usng-tools-js": "git+https://github.com/klassenjs/usng-tools-js.git",
-    "uuid": "^11.1.0"
+    "usng-tools-js": "git+https://github.com/klassenjs/usng-tools-js.git"
   },
   "browserslist": [
     "defaults",

--- a/src/gm3/actions/catalog.js
+++ b/src/gm3/actions/catalog.js
@@ -26,7 +26,7 @@
  *
  */
 
-import { v4 as uuid } from "uuid";
+import { uuid } from "@gm3/uuid";
 import { createAction } from "@reduxjs/toolkit";
 
 import { parseBoolean, getTagContents } from "../util";

--- a/src/gm3/components/serviceInputs/text.js
+++ b/src/gm3/components/serviceInputs/text.js
@@ -24,7 +24,7 @@
 
 import React, { Component } from "react";
 
-import { v4 as uuid } from "uuid";
+import { uuid } from "@gm3/uuid";
 
 export const getId = () => uuid();
 

--- a/src/gm3/reducers/catalog.js
+++ b/src/gm3/reducers/catalog.js
@@ -27,7 +27,7 @@
  */
 
 import { createReducer } from "@reduxjs/toolkit";
-import { v4 as uuid } from "uuid";
+import { uuid } from "@gm3/uuid";
 import {
   addLayer,
   addGroup,

--- a/src/gm3/reducers/mapSource.js
+++ b/src/gm3/reducers/mapSource.js
@@ -26,7 +26,7 @@
  *
  */
 
-import { v4 as uuid } from "uuid";
+import { uuid } from "@gm3/uuid";
 import { createReducer } from "@reduxjs/toolkit";
 import { changeFeatures, filterFeatures } from "../util";
 

--- a/src/gm3/uuid.js
+++ b/src/gm3/uuid.js
@@ -1,0 +1,8 @@
+/**
+ * Small shim over uuid generation that uses crypto.randomUUID()
+ */
+
+export const uuid = () => {
+  // This has been broadly supported in the browser since 2021
+  return crypto.randomUUID();
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,9 @@ module.exports = env => {
             fallback: {
                 url: require.resolve('url'),
             },
+            alias: {
+              "@gm3": path.resolve(__dirname, "src/gm3"),
+            },
         },
         module: {
             rules: [{


### PR DESCRIPTION
Migrates to the built in `crypto.randomUUID` function.

This also adds a `@gm3` prefix for easier package organization.