### PR TITLE
fix: Drop use of crypto.randomUUID

### DIFF
--- a/src/gm3/uuid.js
+++ b/src/gm3/uuid.js
@@ -1,15 +1,62 @@
 /**
- * Small shim over uuid generation that uses an internal counter
- * to generate sequential but unique to the session IDs.
+ * Small shim over UUID generation.
+ *
+ * `crypto.randomUUID()` was used previously, but it is only exposed in
+ * "secure contexts" (HTTPS). Internal sites are frequently deployed over
+ * plain HTTP, where `crypto.randomUUID` is undefined and ID generation
+ * would throw. `crypto.getRandomValues()`, however, is available in
+ * insecure contexts as well, so we use it to build an RFC 4122 version 4
+ * UUID by hand and fall back to `Math.random()` only when Web Crypto is
+ * entirely unavailable.
  */
 
-// "GeoMoose" in hex. or an attempt
-let COUNTER = 0x9e03005e;
+// Lookup table mapping a byte to its two-character hex representation.
+const BYTE_TO_HEX = [];
+for (let i = 0; i < 256; i++) {
+  BYTE_TO_HEX.push((i + 0x100).toString(16).slice(1));
+}
+
+const getRandomBytes = (bytes) => {
+  const cryptoObj = typeof globalThis !== "undefined" ? globalThis.crypto : undefined;
+  if (cryptoObj && typeof cryptoObj.getRandomValues === "function") {
+    cryptoObj.getRandomValues(bytes);
+  } else {
+    // Fallback for environments without Web Crypto. Not cryptographically
+    // strong, but sufficient for generating unique element/source IDs.
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return bytes;
+};
 
 export const uuid = () => {
-  // crypto.randomUUID was used before but internal sites are frequently
-  //  deployed with HTTP. This was preventing IDs from being generated.
-  // There are corner cases where this could fail (merging datasets, using _uuid with WFS)
-  //  but the security risk of the UUID library was more problematic.
-  return `${(++COUNTER).toString(16)}-${Math.floor(Math.random() * 10000).toString(16)}`;
+  const bytes = getRandomBytes(new Uint8Array(16));
+
+  // Set the version (4) and variant (RFC 4122) bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  return (
+    BYTE_TO_HEX[bytes[0]] +
+    BYTE_TO_HEX[bytes[1]] +
+    BYTE_TO_HEX[bytes[2]] +
+    BYTE_TO_HEX[bytes[3]] +
+    "-" +
+    BYTE_TO_HEX[bytes[4]] +
+    BYTE_TO_HEX[bytes[5]] +
+    "-" +
+    BYTE_TO_HEX[bytes[6]] +
+    BYTE_TO_HEX[bytes[7]] +
+    "-" +
+    BYTE_TO_HEX[bytes[8]] +
+    BYTE_TO_HEX[bytes[9]] +
+    "-" +
+    BYTE_TO_HEX[bytes[10]] +
+    BYTE_TO_HEX[bytes[11]] +
+    BYTE_TO_HEX[bytes[12]] +
+    BYTE_TO_HEX[bytes[13]] +
+    BYTE_TO_HEX[bytes[14]] +
+    BYTE_TO_HEX[bytes[15]]
+  );
 };

--- a/src/gm3/uuid.js
+++ b/src/gm3/uuid.js
@@ -1,8 +1,15 @@
 /**
- * Small shim over uuid generation that uses crypto.randomUUID()
+ * Small shim over uuid generation that uses an internal counter
+ * to generate sequential but unique to the session IDs.
  */
 
+// "GeoMoose" in hex. or an attempt
+let COUNTER = 0x9e03005e;
+
 export const uuid = () => {
-  // This has been broadly supported in the browser since 2021
-  return crypto.randomUUID();
+  // crypto.randomUUID was used before but internal sites are frequently
+  //  deployed with HTTP. This was preventing IDs from being generated.
+  // There are corner cases where this could fail (merging datasets, using _uuid with WFS)
+  //  but the security risk of the UUID library was more problematic.
+  return `${(++COUNTER).toString(16)}-${Math.floor(Math.random() * 10000).toString(16)}`;
 };


### PR DESCRIPTION
This fixes ID generation for HTTP hosted sites (common for internal deployments)

@chughes-lincoln -- see if this fixes your problem!