### PR TITLE
feature: Add "links" to the toolbar

### DIFF
--- a/examples/desktop/mapbook.xml
+++ b/examples/desktop/mapbook.xml
@@ -563,5 +563,10 @@
         <tool name="reload" title="Start Over" type="action"/>
         <tool name="bookmark" title="Bookmark" type="action"/>
         <tool name="open-streetview" title="3D View" type="service" />
+
+        <drawer name="helpful-links" title="Helpful Links" tip="External resources">
+            <tool name="geomoose-home" type="link" href="https://geomoose.org/" title="GeoMoose Home"/>
+            <tool name="geomoose-docs" type="link" href="https://docs.geomoose.org/" title="Documentation"/>
+        </drawer>
     </toolbar>
 </mapbook>

--- a/src/gm3/actions/toolbar.js
+++ b/src/gm3/actions/toolbar.js
@@ -60,6 +60,7 @@ function parseTool(toolXml) {
     actionDetail: toolXml.getAttribute("action"),
     cssClass: toolXml.getAttribute("css-class"),
     tip: toolXml.getAttribute("tip"),
+    href: toolXml.getAttribute("href"),
   };
 }
 

--- a/src/gm3/components/toolbar/button.js
+++ b/src/gm3/components/toolbar/button.js
@@ -46,6 +46,7 @@ export const ToolbarButton = ({ tool, runAction, startService, currentService, s
   const label = t(tool.label);
   const tip = tool.tip ? t(tool.tip) : label;
   const active = tool.name === currentService;
+  const className = `${active ? "active " : ""}${tool.cssClass || "tool " + tool.name}`;
 
   const onClick = useCallback(() => {
     if (tool.actionType === "service") {
@@ -59,13 +60,29 @@ export const ToolbarButton = ({ tool, runAction, startService, currentService, s
     }
   }, [startService, tool, serviceDef, runAction]);
 
+  if (tool.actionType === "link") {
+    const linkClass = `${active ? "active " : ""}${tool.cssClass || `tool link ${tool.name}`}`;
+    return (
+      <a
+        className={`toolbar-button ${linkClass}`}
+        href={tool.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={tip}
+      >
+        <span className="icon"></span>
+        <span className="label">{label}</span>
+      </a>
+    );
+  }
+
   return (
     <BaseToolbarButton
       key={tool.name}
       onClick={onClick}
       label={label}
       tip={tip}
-      className={`${active ? "active " : ""}${tool.cssClass || "tool " + tool.name}`}
+      className={className}
     />
   );
 };

--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -3,6 +3,7 @@
   align-items: center;
 
   .tool {
+    box-sizing: border-box;
     height: 22px;
     padding: 2px 7px;
     font-size: 14px;
@@ -12,9 +13,16 @@
     margin-bottom: 4px;
     margin-right: 4px;
 
+    color: inherit;
+    text-decoration: none;
+
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    &:visited {
+      color: inherit;
+    }
 
     &:hover {
       cursor: pointer;
@@ -155,6 +163,15 @@
     .fa;
     &:before {
       content: @fa-var-bookmark-o;
+    }
+  }
+}
+
+.tool.link {
+  .icon {
+    .fa;
+    &:before {
+      content: @fa-var-external-link;
     }
   }
 }

--- a/tests/gm3/components/toolbar.test.js
+++ b/tests/gm3/components/toolbar.test.js
@@ -164,4 +164,42 @@ describe("Toolbar component tests", () => {
 
     expect(store.getState().ui.action).toBe("sample0");
   });
+
+  it("renders a link tool as an anchor with the configured href.", function () {
+    const tool = {
+      name: "helpful-link",
+      label: "Helpful Link",
+      actionType: "link",
+      href: "https://geomoose.org/",
+    };
+
+    const { container } = render(<SmartToolbarButton tool={tool} store={store} />);
+    const anchor = container.querySelector("a.tool");
+
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute("href")).toBe("https://geomoose.org/");
+    expect(anchor.getAttribute("target")).toBe("_blank");
+    expect(anchor.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("parses a link tool from a mapbook fragment.", function () {
+    const toolbarXml = `
+            <toolbar>
+                <drawer name="helpful-links" title="Helpful Links">
+                    <tool name="docs" type="link" href="https://docs.geomoose.org/" title="Docs"/>
+                </drawer>
+            </toolbar>`;
+
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(toolbarXml, "text/xml");
+    const results = actions.parseToolbar(xml.getElementsByTagName("toolbar")[0]);
+
+    results.forEach((action) => {
+      store.dispatch(action);
+    });
+
+    const linkTool = store.getState().toolbar["helpful-links"][0];
+    expect(linkTool.actionType).toBe("link");
+    expect(linkTool.href).toBe("https://docs.geomoose.org/");
+  });
 });


### PR DESCRIPTION
Allow the user to define a link to an external site in the toolbar.

This was a GM2.x feature that never made its way to 3.x!