### PR TITLE
fix: Font structure, radio and checkbox rendering

### DIFF
--- a/src/less/catalog.less
+++ b/src/less/catalog.less
@@ -26,7 +26,7 @@
 
 .group {
   .group {
-    padding-left: 20px;
+    padding-left: @gm-control-size;
   }
 
   .group-label {
@@ -36,14 +36,18 @@
     align-items: center;
 
     input[type="checkbox"] {
-      /* force fontawesome for the checkbox */
-      .fa;
+      /* render a fontawesome chevron instead of a checkbox */
       border: none;
 
       &::before {
-        display: inline-block;
+        .fa;
+
         content: @fa-var-chevron-right;
-        transform: translateX(50%) translateY(0%);
+        width: auto;
+        height: auto;
+        box-shadow: none;
+        clip-path: none;
+        transform: none;
       }
 
       transition: 120ms transform ease-in-out;
@@ -51,9 +55,6 @@
 
       &:checked {
         transform: rotate(90deg);
-        &::before {
-          transform: translateX(50%) translateY(-50%);
-        }
       }
     }
 
@@ -63,7 +64,7 @@
   }
 
   .layer {
-    padding-left: 20px;
+    padding-left: @gm-control-size;
   }
 
   &.gm-collapse {
@@ -88,8 +89,8 @@
   }
 }
 
-@checkbox-width: 20px;
-@checkbox-margin: 2px;
+@checkbox-width: @gm-control-size;
+@checkbox-margin: 0.125em;
 
 .layer {
   /* unstyle the tool buttons */
@@ -102,6 +103,10 @@
 
   .layer-label {
     cursor: pointer;
+    /* center the toggle, favorite, and label on a common axis,
+     * the same way .group-label does. */
+    display: flex;
+    align-items: center;
 
     .checkbox {
       margin: @checkbox-margin;
@@ -139,17 +144,17 @@
   .layer-tools {
     .icon {
       color: #333;
-      font-size: 20px;
-      width: 28px;
-      height: 28px;
-      border-radius: 14px;
+      font-size: @gm-control-size;
+      width: 1.75em;
+      height: 1.75em;
+      border-radius: 50%;
 
       display: inline-flex;
       justify-content: center;
       align-items: center;
 
-      margin-right: 4px;
-      margin-bottom: 4px;
+      margin-right: 0.25em;
+      margin-bottom: 0.25em;
 
       &:hover {
         box-shadow: 0 0 1px 1px #a09999;
@@ -165,6 +170,17 @@
   input[type="checkbox"].favorite {
     color: @favorite-star-color;
     border: none;
+
+    /* the star glyphs come from .icon.favorite in icons.less */
+    &::before {
+      .fa;
+
+      width: auto;
+      height: auto;
+      box-shadow: none;
+      clip-path: none;
+      transform: none;
+    }
   }
 }
 

--- a/src/less/catalog.less
+++ b/src/less/catalog.less
@@ -93,12 +93,14 @@
 @checkbox-margin: 0.125em;
 
 .layer {
-  /* unstyle the tool buttons */
+  /* unstyle the tool buttons; buttons do not inherit font by
+   * default, which would detach the icons from the panel scale. */
   button {
     margin: 0;
     padding: 0;
     background: none;
     border: none;
+    font: inherit;
   }
 
   .layer-label {
@@ -119,11 +121,13 @@
     padding-left: (@checkbox-width + @checkbox-margin * 2);
   }
 
+  /* keep all of the row's glyphs on the label's scale; the layer
+   * toggle stays the visually-largest control in the row. */
   .metadata.icon,
   .favorite.icon,
   .refresh.icon,
   .checkbox.icon {
-    font-size: 110%;
+    font-size: 1em;
   }
 
   .favorite.icon {
@@ -196,6 +200,10 @@
 }
 
 .catalog {
+  /* dense-panel scale: the labels and, through their em sizing,
+   * the controls and glyphs all step down together. */
+  font-size: @gm-text-ui;
+
   .searchbox {
     position: absolute;
     width: 100%;
@@ -209,7 +217,7 @@
       margin: 4px;
       text-align: left;
       width: 85%;
-      height: 20px;
+      height: 1.5em;
     }
   }
 

--- a/src/less/gm3.less
+++ b/src/less/gm3.less
@@ -25,6 +25,7 @@
 @import (inline) "../../node_modules/ol/ol.css";
 @import "../../node_modules/font-awesome/less/font-awesome.less";
 @import (inline) "../../node_modules/mapskin/css/mapskin.min.css";
+@import "variables.less";
 @import "modal.less";
 @import "icons.less";
 @import "catalog.less";
@@ -89,7 +90,7 @@
   background-color: lightsteelblue;
   margin: 7px;
   padding: 5px;
-  font-size: 10pt;
+  font-size: @gm-text-secondary;
 }
 
 .spinner {
@@ -117,21 +118,18 @@ input[type="checkbox"] {
   font: inherit;
   color: currentColor;
 
-  width: 1em;
-  height: 1em;
-  border: 0.15em solid currentColor;
+  width: @gm-control-size;
+  height: @gm-control-size;
+  border: @gm-control-stroke solid currentColor;
   margin: 0.5em;
   margin-left: 0;
-}
+  vertical-align: middle;
 
-input[type="radio"],
-input[type="checkbox"] {
-  border-radius: 50%;
+  /* the checked-state mark; drawn with the box-shadow fill so it
+   * follows currentColor and stays geometrically centered by the
+   * grid at any font-size. */
   &::before {
     content: "";
-    width: 0.65em;
-    height: 0.65em;
-    border-radius: 50%;
     transform: scale(0);
     transition: 120ms transform ease-in-out;
     box-shadow: inset 1em 1em currentColor;
@@ -140,18 +138,31 @@ input[type="checkbox"] {
   &:checked::before {
     transform: scale(1);
   }
+
+  /* appearance: none also removes the native focus ring */
+  &:focus-visible {
+    outline: @gm-control-stroke solid currentColor;
+    outline-offset: 0.125em;
+  }
+}
+
+input[type="radio"] {
+  border-radius: 50%;
+
+  &::before {
+    width: 0.6em;
+    height: 0.6em;
+    border-radius: 50%;
+  }
 }
 
 input[type="checkbox"] {
-  border-radius: 10%;
+  border-radius: 0.2em;
+
   &::before {
-    content: "\2714";
-    width: 0.5em;
-    height: 0.5em;
-    box-shadow: none;
-  }
-  &:checked::before {
-    transform: scale(1) translateY(-0.5em) translateX(-0.125em);
+    width: 0.7em;
+    height: 0.7em;
+    clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
   }
 }
 

--- a/src/less/icons.less
+++ b/src/less/icons.less
@@ -25,7 +25,7 @@
 @folder-color: #333333;
 @refresh-icon-disabled-color: #82a984;
 @refresh-icon-enabled-color: #5df265;
-@icon-size: 20px;
+@icon-size: @gm-control-size;
 
 .icon {
   font: normal normal normal @icon-size / 1 mapskin;

--- a/src/less/modal.less
+++ b/src/less/modal.less
@@ -49,7 +49,7 @@
   h5 {
     color: #333;
     font-weight: bold;
-    font-size: 22px;
+    font-size: @gm-text-title;
     overflow: hidden;
     text-overflow: ellipsis;
     margin: 4px;

--- a/src/less/results.less
+++ b/src/less/results.less
@@ -55,7 +55,7 @@
     background-color: #cfe7b3;
     padding: 5px;
     font-weight: bold;
-    font-size: 110%;
+    font-size: @gm-text-header;
     clear: both;
   }
 
@@ -64,7 +64,7 @@
     display: none;
 
     font-style: italic;
-    font-size: 10px;
+    font-size: @gm-text-fine;
     padding: 4px;
     padding-top: 2px;
     padding-bottom: 2px;
@@ -91,7 +91,7 @@
 
       .label {
         width: 100%;
-        font-size: 0.75em;
+        font-size: @gm-text-fine;
         text-overflow: ellipsis;
         white-space: nowrap;
       }
@@ -139,7 +139,7 @@
 
     .results-info-item.filtered-features {
       font-style: italic;
-      font-size: 0.9em;
+      font-size: @gm-text-secondary;
       margin-top: 5px;
     }
   }

--- a/src/less/serviceForms.less
+++ b/src/less/serviceForms.less
@@ -58,7 +58,7 @@
       background-color: #cfe7b3;
       padding: 5px;
       font-weight: bold;
-      font-size: 110%;
+      font-size: @gm-text-header;
       clear: both;
     }
 

--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -4,14 +4,14 @@
 
   .tool {
     box-sizing: border-box;
-    height: 22px;
-    padding: 2px 7px;
-    font-size: 14px;
+    height: 1.6em;
+    padding: 0.15em 0.5em;
+    font-size: @gm-text-secondary;
     border: none;
     background: none;
-    border-radius: 11px;
-    margin-bottom: 4px;
-    margin-right: 4px;
+    border-radius: 0.8em;
+    margin-bottom: 0.25em;
+    margin-right: 0.25em;
 
     color: inherit;
     text-decoration: none;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2017, 2025 Dan "Ducky" Little
+ * Copyright (c) 2026 Dan "Ducky" Little
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,13 +22,20 @@
  * SOFTWARE.
  */
 
-.attribution-display {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  z-index: 99;
-  background: rgba(255, 255, 255, 0.5);
-  border-radius: 5px;
-  margin: 10px;
-  font-size: @gm-text-fine;
-}
+/* Shared sizing scale.
+ *
+ * Everything is em-based so the whole UI scales together from the
+ * font-size of the embedding element.  At the browser-default 16px
+ * base, @gm-control-size works out to the 20px the icons have
+ * historically used.
+ */
+
+/* checkboxes, radios, and icon glyphs share one optical size */
+@gm-control-size: 1.25em;
+@gm-control-stroke: 0.125em;
+
+/* text roles */
+@gm-text-title: 1.375em;
+@gm-text-header: 1.125em;
+@gm-text-secondary: 0.875em;
+@gm-text-fine: 0.75em;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -39,3 +39,8 @@
 @gm-text-header: 1.125em;
 @gm-text-secondary: 0.875em;
 @gm-text-fine: 0.75em;
+
+/* dense panel UIs (the catalog tree, etc.) use a smaller base than
+ * page content; labels land at 14px on a 16px page and the em-sized
+ * controls follow at 17.5px. */
+@gm-text-ui: 0.875em;


### PR DESCRIPTION
I noticed some bugs on HiDPI screens and definitely some quirks with some of the recent font-changes on `main`.

Spent some time refactoring and then massaging the fonts a little to fix:
1. Issues with font-sizes being arbitrary (they're not enumed in a single variables file)
2. Issues with the radio buttons and checkboxes. @klassenjs noticed this too, where on some screens the font rendering would make these look uneven. That's been corrected now.

<img width="2192" height="1242" alt="image" src="https://github.com/user-attachments/assets/ede73a69-4154-4025-b077-e6c2038cd052" />
