### PR TITLE
fix: Start Over should preserve the current mapbook

### DIFF
--- a/examples/desktop/app.js
+++ b/examples/desktop/app.js
@@ -295,8 +295,14 @@ app.loadMapbook().then(function() {
             app.confirm('reload-okay', reload_msg, function(response) {
                 if(response === 'confirm') {
                     document.location.hash = '';
-                    if (document.location.search.length > 0) {
-                      document.location.search = '';
+                    // Clear the query string but preserve "safe" params
+                    // (e.g. "mapbook") so Start Over keeps using the
+                    // current mapbook instead of always reverting to
+                    // the default one.
+                    var currentSearch = document.location.search.replace(/^\?/, '');
+                    var nextSearch = gm3.util.buildSafeQueryString(document.location.search);
+                    if (nextSearch !== currentSearch) {
+                      document.location.search = nextSearch;
                     } else {
                       document.location.reload();
                     }

--- a/src/gm3/util.js
+++ b/src/gm3/util.js
@@ -53,6 +53,24 @@ export function parseQuery() {
   return paramStringToObject(window.location.search);
 }
 
+/**
+ * Build a new query string containing only the parameters
+ * named in safeList, taken from an existing query string.
+ * Used when resetting the app (e.g. "Start Over") so that
+ * structural parameters like "mapbook" survive the reset
+ * while transient ones do not.
+ */
+export function buildSafeQueryString(searchString, safeList = ["mapbook"]) {
+  const params = new URLSearchParams(searchString);
+  const safeParams = new URLSearchParams();
+  safeList.forEach((paramName) => {
+    if (params.has(paramName)) {
+      safeParams.set(paramName, params.get(paramName));
+    }
+  });
+  return safeParams.toString();
+}
+
 export function parseBoolean(bool, def = false) {
   if (typeof bool == "undefined" || bool === null) {
     return def;

--- a/tests/gm3/util.test.js
+++ b/tests/gm3/util.test.js
@@ -10,6 +10,24 @@ test("parseBoolean", () => {
   expect(util.parseBoolean("true")).toBe(true);
 });
 
+describe("buildSafeQueryString", () => {
+  test("preserves a param on the default safe list", () => {
+    expect(util.buildSafeQueryString("?mapbook=test&other=1")).toBe("mapbook=test");
+  });
+
+  test("returns an empty string when nothing on the safe list is present", () => {
+    expect(util.buildSafeQueryString("?other=1&another=2")).toBe("");
+  });
+
+  test("returns an empty string for an empty query string", () => {
+    expect(util.buildSafeQueryString("")).toBe("");
+  });
+
+  test("honors a custom safe list", () => {
+    expect(util.buildSafeQueryString("?a=1&b=2&c=3", ["b", "c"])).toBe("b=2&c=3");
+  });
+});
+
 /*
  * Test the query filter matching.
  */


### PR DESCRIPTION
**Disclosure: I'm an AI coding agent** (Claude, operating the @MayzrBot account). This PR was written and tested by me; a human reviews before anything is merged. Happy to answer questions or make changes.

## Summary

Closes #993.

"Start Over" (`examples/desktop/app.js`) clears `document.location.search` entirely before reloading. But which mapbook is loaded is selected via a `mapbook` query param (`Application.loadMapbook()` reads `parseQuery().mapbook`, defaulting to `"default"` if absent). So on the demo/protocols apps that use a non-default mapbook (e.g. `?mapbook=test`), "Start Over" always drops the user back to the default mapbook instead of the one they were actually using.

This regressed in #803 (2023), which added the search-clearing behavior to fix a different reload bug (`document.location.reload()` didn't work when only the hash had changed) — clearing the query string was collateral, not the intent.

## Fix

Added `util.buildSafeQueryString(searchString, safeList = ['mapbook'])`, which mirrors the `safeList`/"preserve certain params" pattern that `Application.startServiceFromQuery()` already uses for the exact same purpose (see `src/gm3/application.js` around line 970). The reload action in `examples/desktop/app.js` now uses it to keep `mapbook` (and any future safe params) across Start Over, while still clearing everything else, including the hash.

## Testing

- Added unit tests for `buildSafeQueryString` in `tests/gm3/util.test.js` (4 cases: default safe list, no safe params present, empty query string, custom safe list).
- Ran the full suite: `NODE_ENV=test npx jest` → 120/120 passing (note: `NODE_ENV=production` in my sandbox made React's testing-library `act()` calls fail across many component tests unrelated to this change — forcing `NODE_ENV=test` fixed that and confirmed it wasn't caused by this diff).
- `npx eslint ./src ./tests` → clean (0 errors).
- `node --check examples/desktop/app.js` → syntax OK.
- Traced the fix against the actual reported repro (`?mapbook=test#...` on the Protocols Demo app): hash is cleared, `mapbook=test` now survives in the query string, everything else is dropped, matching the existing `startServiceFromQuery` precedent.

I wasn't able to run the live webpack dev server / browser flow in my sandbox (no way to click through the UI), so this is verified at the unit + code-tracing level, not with an end-to-end browser test. Flagging that explicitly rather than claiming more than I checked.