### PR TITLE
fix: Only print the scale label when the map rendered at that scale

### DIFF
--- a/docs/howto/configure-print-scales.rst
+++ b/docs/howto/configure-print-scales.rst
@@ -82,3 +82,48 @@ Scale                     ``scale``    Typical use
 
     Scales assume a basemap in meters (web mercator) and are true at the
     map center; like any web-mercator map, scale distorts toward the poles.
+
+Zoom restrictions and the offered scales
+----------------------------------------
+
+Printing at a fixed scale re-renders the map at the resolution that scale
+requires. The print map is rendered by the same map component as the main
+map, so it inherits any ``map.view`` zoom restrictions -- and a scale
+finer than those restrictions permit **cannot be honored**.
+
+::
+
+    var app = new gm3.Application({
+        map: {
+            view: {
+                maxZoom: 20
+            }
+        }
+    });
+
+With ``maxZoom: 20``, a request for ``1 inch = 10 feet`` cannot be met:
+OpenLayers clamps the render at the zoom-20 limit, and the map comes out
+several times coarser than asked for.
+
+The same applies at the other end. ``view.extent`` caps how far out the
+map can zoom -- the extent has to fit the printed map's pixel size -- so
+a very coarse scale on a tightly bounded map is equally unreachable.
+
+**Unreachable scales are not offered.** GeoMoose tests each configured
+scale against the view's limits and leaves out the ones it cannot honor,
+so a user cannot select a scale the print would silently fail to deliver.
+Any dropped scales are named in the print dialog and in the browser
+console.
+
+.. warning::
+
+    A scale you configured can therefore be missing from the print dialog
+    on some layouts and present on others -- the check depends on the size
+    of the layout's map element as well as on the zoom limits.
+
+The fix is to make the settings agree: either widen the zoom limits far
+enough to reach your finest and coarsest scales, or set ``print.scales``
+so only reachable scales are offered.
+
+The printed scale caption is drawn only for a scale that passed this
+check -- see the **Scale line** option in :doc:`configure-scaleline`.

--- a/docs/howto/configure-scaleline.rst
+++ b/docs/howto/configure-scaleline.rst
@@ -21,4 +21,72 @@ Example:
 
 Valid values: \* ``enabled`` - Boolean. ``true`` or ``false`` \*
 ``units`` - String. ``'degrees'``, ``'imperial'``, ``'nautical'``,
-``'metric'``, ``'us'``
+``'metric'``, ``'us'`` \* ``printMode`` - String. ``'none'``,
+``'line-distance'``, ``'line-distance-scale'``
+
+The scale line on printed maps
+------------------------------
+
+When the scale line is enabled, the print dialog gains a **Scale line**
+option controlling what the printed map's scale indicator shows:
+
+============================  ==========================================
+Option                        Shows
+============================  ==========================================
+None                          No scale indicator at all
+Line and Distance             The bar, labeled with the ground distance
+                              it spans (e.g. ``300 ft``)
+Line, Distance, and Scale     The above, captioned with the scale the
+                              map was printed at (e.g. ``100 ft / in``)
+============================  ==========================================
+
+``printMode`` sets which of these a print starts on; the user can change
+it for any individual print. It defaults to ``'line-distance-scale'``.
+
+Once the user has seen the control, only the user moves it. If the
+selected mode stops being possible -- picking a "Scale to fit" preset,
+which names no scale to caption -- the dialog settles on the nearest
+mode it can offer and stays there. It will not quietly restore the
+caption later when a fixed scale is chosen again, because a print
+should match what the dialog last showed.
+
+One consequence is worth knowing: the print dialog opens on "Scale to
+fit", where a caption is impossible, so a ``printMode`` of
+``'line-distance-scale'`` settles to ``'line-distance'`` on open. The
+caption is then something the user turns on after choosing a scale,
+rather than something they have to notice and turn off.
+
+::
+
+    var app = new gm3.Application({
+        map: {
+            scaleLine: {
+                enabled: true,
+                units: 'us',
+                printMode: 'line-distance'
+            }
+        }
+    });
+
+Choosing a default is worth a moment's thought, because the bar and the
+caption fail differently once the PDF leaves your hands. A scale in
+writing only holds for the page it was made for: a PDF exported at
+``1 inch = 10 feet`` and then reprinted at another paper size, or with
+the printer's "fit to printable area" on, carries a caption that is no
+longer true. The bar is drawn on the page itself, so resizing the page
+resizes the bar with it and it goes on describing the map correctly.
+
+``'line-distance-scale'`` suits maps read on screen or printed at the
+size they were made for. ``'line-distance'`` suits offices where PDFs
+are circulated and reprinted freely, and is the safer default when you
+cannot know how a map will be reproduced.
+
+.. note::
+
+    The "Scale" option is offered only when the print can honor a scale:
+    the "Scale to fit" presets name no scale, and a scale the map's zoom
+    limits cannot reach is left out rather than printed as a number the
+    map does not honor. See :doc:`configure-print-scales`.
+
+Setting ``enabled: false`` removes the scale line from printed maps
+entirely, and the **Scale line** option does not appear in the dialog.

--- a/src/gm3/components/print/printModal.js
+++ b/src/gm3/components/print/printModal.js
@@ -151,6 +151,37 @@ const toPoints = (n, unit) => {
 // TODO: derive this from state once non-mercator basemaps are supported.
 const MAP_PROJECTION = "EPSG:3857";
 
+// Relative tolerance when comparing a requested resolution against the one
+//  OpenLayers will actually use. Well below any real zoom step, so it only
+//  ever absorbs floating-point drift.
+const RESOLUTION_EPSILON = 1e-6;
+
+// What the printed map's scale indicator shows. Each mode is the previous
+//  one plus an element: the bar with its distance label ("300 ft"), then
+//  the fixed-scale caption ("100 ft / in") beside it.
+//
+// A bar with no distance label is deliberately not offered -- there would
+//  be no way to tell what the bar measures.
+const SCALE_LINE_NONE = "none";
+const SCALE_LINE_DISTANCE = "line-distance";
+const SCALE_LINE_DISTANCE_SCALE = "line-distance-scale";
+
+const SCALE_LINE_MODES = [SCALE_LINE_NONE, SCALE_LINE_DISTANCE, SCALE_LINE_DISTANCE_SCALE];
+
+/* The scale-line mode a print starts on, from config.map.scaleLine.printMode.
+ *
+ * Offices that circulate PDFs for reprinting often want the fixed-scale
+ * caption off by default, since a caption stops being true once the page
+ * is resized. An unrecognized value falls back to showing everything.
+ */
+function getConfiguredScaleLineMode(state) {
+  const scaleLine = state.config.map.scaleLine;
+  if (scaleLine && SCALE_LINE_MODES.indexOf(scaleLine.printMode) >= 0) {
+    return scaleLine.printMode;
+  }
+  return SCALE_LINE_DISTANCE_SCALE;
+}
+
 // Unit conversions used to express scale presets.
 
 const POINTS_PER_INCH = 72;
@@ -240,6 +271,8 @@ export class PrintModal extends Modal {
       resolution: "fit",
       layouts: props.layouts ? props.layouts : DefaultLayouts,
       includeSelection: "true",
+      // the deployer picks the starting mode; the user changes it per print.
+      scaleLineMode: getConfiguredScaleLineMode(props.store.getState()),
     };
   }
 
@@ -418,7 +451,8 @@ export class PrintModal extends Modal {
 
     // add a scale line
     const scaleLine = state.config.map.scaleLine;
-    if (scaleLine && scaleLine.enabled) {
+    const scaleLineMode = this.getScaleLineMode();
+    if (scaleLine && scaleLine.enabled && scaleLineMode !== SCALE_LINE_NONE) {
       // the view renders at "render-pixel" resolution; the scale bar is
       //  drawn in PDF points, so scale up by the image's pixels-per-point.
       const scaleInfo = getScalelineInfo(view, scaleLine.units || "us", {
@@ -439,10 +473,14 @@ export class PrintModal extends Modal {
       // the end ticks rise from the line to 60% of the label's height.
       const tickHeight = 0.6 * labelHeight;
 
-      // when a fixed scale is chosen, caption the indicator with that
-      //  scale's label (e.g. "1:24000"); "Fit" scales have no fixed ratio.
-      const scaleDef = this.getScales().find((s) => s.value === this.state.resolution);
-      const fixedLabel = scaleDef && !scaleDef.fit ? scaleDef.label : null;
+      // the fixed-scale caption (e.g. "100 ft / in") beside the bar. It is
+      //  offered only when the map will really render at that scale, so by
+      //  the time the mode asks for it the choice is already sound --
+      //  getScaleLineMode drops back to the bar alone otherwise.
+      let fixedLabel = null;
+      if (scaleLineMode === SCALE_LINE_DISTANCE_SCALE) {
+        fixedLabel = this.getScaleDef().label;
+      }
 
       // the scale line itself, mirroring the OpenLayers scale line: a
       //  horizontal distance line capped with a tick on each end.
@@ -686,7 +724,7 @@ export class PrintModal extends Modal {
     return <div className={this.getFooterClass(2)}>{buttons}</div>;
   }
 
-  /* The full list of scale options shown to the user.
+  /* Every configured scale, whether or not this map can render it.
    *
    * The "Fit" options are always present; the fixed scales come from the
    * application config (config.print.scales) when provided. When scales are
@@ -695,13 +733,226 @@ export class PrintModal extends Modal {
    *
    * @return An array of scale definitions.
    */
-  getScales() {
+  getAllScales() {
     const configScales = this.props.printScales;
     const fixedScales =
       configScales === undefined
         ? DEFAULT_SCALES
         : configScales.map((def, i) => buildScale(def, i)).filter((scale) => scale !== null);
     return [...FIT_SCALES, ...fixedScales];
+  }
+
+  /* The map resolution a scale needs, without consulting the scale list.
+   *
+   * Split out from getPrintMap so getScales can test a scale for
+   * reachability -- getPrintMap picks from getScales, so deriving this
+   * there would be circular.
+   *
+   * @return meters/pixel, or null for a "fit" scale (which has no fixed
+   *   ground distance and renders at the current view resolution).
+   */
+  getResolutionForScaleDef(scaleDef) {
+    if (scaleDef.fit) {
+      return null;
+    }
+    // the image renders at dpiMultiplier pixels per PDF point, so the
+    //  ground distance each pixel must cover is the per-point distance
+    //  spread across those pixels.
+    const groundResolution = scaleDef.metersPerPt / SCALE_DPI_MULTIPLIER;
+    // web mercator (EPSG:3857) stretches distances by latitude, so the
+    //  view resolution OL renders with is not true ground meters. Convert
+    //  the desired ground resolution into a projected one at the map
+    //  center; this also keeps the scale bar (which corrects the same
+    //  way) in agreement with the printed map.
+    const projectionFactor = getPointResolution(MAP_PROJECTION, 1, this.props.mapView.center, "m");
+    return groundResolution / projectionFactor;
+  }
+
+  /* The scale options offered to the user.
+   *
+   * A scale finer than the map's zoom limits allow cannot be honored --
+   * OpenLayers clamps the render and the print comes out at some other
+   * scale entirely -- so it is left off the menu rather than offered and
+   * quietly not delivered.
+   *
+   * The trade-off is that a deployer can configure a scale their zoom
+   * limits hide, so getUnavailableScales names the dropped ones and the
+   * dialog shows them.
+   *
+   * Deliberately not memoized. Testing a scale costs an OpenLayers view,
+   * but that is ~0.02ms -- a fraction of a millisecond for a whole render
+   * of a dialog that only re-renders on interaction. A cache here would
+   * have to be keyed on the configured scales, the view limits, the map
+   * center, and the layout, and would silently go stale for any subclass
+   * that overrides one of the inputs.
+   *
+   * @return An array of scale definitions.
+   */
+  getScales() {
+    return this.getAllScales().filter((scaleDef) => this.canRenderScale(scaleDef));
+  }
+
+  /* Labels of the configured scales this map cannot reach.
+   *
+   * Surfaced in the dialog so a scale going missing is visible to the
+   * person printing, not only to whoever opens the console.
+   */
+  getUnavailableScales() {
+    return this.getAllScales()
+      .filter((scaleDef) => !this.canRenderScale(scaleDef))
+      .map((scaleDef) => scaleDef.label);
+  }
+
+  /* Whether this map can be rendered at a scale's resolution. */
+  canRenderScale(scaleDef) {
+    return this.canRenderAtResolution(this.getResolutionForScaleDef(scaleDef));
+  }
+
+  /* The pixel size the print map image is rendered at, for a fixed scale.
+   *
+   * canRenderAtResolution needs this: when config.map.view sets an extent,
+   * OpenLayers caps the resolution at the extent divided by the *viewport*,
+   * so a check run against a differently-sized viewport gets a different
+   * answer. Derived from the layout alone so getScales can call it without
+   * going through getPrintMap, which picks from getScales.
+   *
+   * Only fixed scales need this, and those always render at
+   * SCALE_DPI_MULTIPLIER; "fit" scales are never resolution-constrained.
+   *
+   * @return [width, height] in pixels, or null when the layout has no map.
+   */
+  getPrintMapSize() {
+    const layout = this.state.layouts[this.state.layout];
+    if (!layout) {
+      return null;
+    }
+    const mapElement = layout.elements.find((element) => element.type === "map");
+    if (!mapElement) {
+      return null;
+    }
+    return [
+      this.toPoints(mapElement.width, layout.units) * SCALE_DPI_MULTIPLIER,
+      this.toPoints(mapElement.height, layout.units) * SCALE_DPI_MULTIPLIER,
+    ];
+  }
+
+  /* Whether the print map can actually render at a given resolution.
+   *
+   * The print image is rendered by the same map component as the main map
+   * (see PrintImage), so it inherits config.map.view's minZoom/maxZoom. A
+   * scale finer than maxZoom permits is silently clamped by OpenLayers: the
+   * printed map comes out at whatever the limit allows, not at the scale
+   * that was asked for. Ask OpenLayers what it would clamp to and compare.
+   */
+  canRenderAtResolution(resolution) {
+    if (resolution === null || resolution === undefined) {
+      return true;
+    }
+
+    const viewConfig = this.props.store.getState().config.map.view;
+    if (!viewConfig) {
+      return true;
+    }
+
+    // mirror how the map component seeds its view (see components/map),
+    //  since only these keys constrain the resolution.
+    const viewParams = {
+      center: this.props.mapView.center,
+      resolution,
+      projection: MAP_PROJECTION,
+    };
+    ["maxZoom", "minZoom", "extent"].forEach((key) => {
+      if (viewConfig[key]) {
+        viewParams[key] = viewConfig[key];
+      }
+    });
+
+    const view = new View(viewParams);
+    // with an extent configured, the constraint is the extent spread across
+    //  the viewport, so this has to be the size the print map really mounts
+    //  at. Left at OpenLayers' 100x100 default it reads far too permissive.
+    const size = this.getPrintMapSize();
+    if (size) {
+      view.setViewportSize(size);
+    }
+
+    const constrained = view.getConstrainedResolution(resolution);
+    if (constrained === undefined) {
+      return true;
+    }
+
+    // floating point: a clamp that lands within a hair of the request is
+    //  the request.
+    return Math.abs(constrained - resolution) <= resolution * RESOLUTION_EPSILON;
+  }
+
+  /* The scale this print will actually use.
+   *
+   * Which scales are reachable depends on the layout and the map center,
+   * so a scale the user picked can drop out of the list underneath them --
+   * changing layouts is enough. Rather than leave the picker showing a
+   * value it no longer offers (and printing something else), fall back to
+   * the first scale, which is always "Scale to fit".
+   */
+  getScaleDef() {
+    const scales = this.getScales();
+    return scales.find((s) => s.value === this.state.resolution) || scales[0];
+  }
+
+  /* Whether the fixed-scale caption can be offered for the current choices.
+   *
+   * It needs a scale to name, so the "fit" presets rule it out. Anything
+   * still in getScales() is by definition a scale the map can render, so
+   * no further check is needed here: a scale the zoom limits would clamp
+   * was already dropped from the list and cannot be the selection.
+   */
+  canShowFixedScale() {
+    return !this.getScaleDef().fit;
+  }
+
+  /* The scale-line mode this print will actually use.
+   *
+   * The scale and scale-line pickers are independent, so the caption can
+   * stop being available -- switching to a "fit" preset, which names no
+   * scale -- while it is the selected mode. The print then falls back to
+   * the bar alone.
+   *
+   * componentDidUpdate commits that fallback, so this only ever differs
+   * from state within the render that discovers it. Whatever the control
+   * shows is what prints, and it never changes on its own afterwards.
+   */
+  getScaleLineMode() {
+    const mode = this.state.scaleLineMode;
+    if (mode === SCALE_LINE_DISTANCE_SCALE && !this.canShowFixedScale()) {
+      return SCALE_LINE_DISTANCE;
+    }
+    return mode;
+  }
+
+  /* Hold the scale-line picker to what the user last saw.
+   *
+   * Without this the mode is merely derived, so a user who opens the
+   * dialog on a "fit" preset sees "Line and Distance" -- the caption
+   * being unavailable -- leaves it alone, picks a fixed scale, and the
+   * control silently jumps to "Line, Distance, and Scale" because the
+   * underlying state was never what the control displayed. They get a
+   * caption they had no reason to expect.
+   *
+   * Committing the fallback means the user's choice is the only thing
+   * that moves this control. The cost is that scaleLine.printMode only
+   * takes effect while the caption is available: a dialog that opens on
+   * a "fit" preset settles on "Line and Distance", and a deployer's
+   * "line-distance-scale" default is then something the user opts into
+   * rather than out of. That is the safer direction to err.
+   */
+  componentDidUpdate(prevProps, prevState) {
+    if (super.componentDidUpdate) {
+      super.componentDidUpdate(prevProps, prevState);
+    }
+    const mode = this.getScaleLineMode();
+    if (mode !== this.state.scaleLineMode) {
+      this.setState({ scaleLineMode: mode });
+    }
   }
 
   /* The rendering parameters for the print map.
@@ -724,8 +975,7 @@ export class PrintModal extends Modal {
    */
   getPrintMap() {
     const layout = this.state.layouts[this.state.layout];
-    const scales = this.getScales();
-    const scaleDef = scales.find((s) => s.value === this.state.resolution) || scales[0];
+    const scaleDef = this.getScaleDef();
 
     // "fit" scales are a simple DPI multiplier on the layout size; fixed
     //  scales render at a constant, print-quality DPI.
@@ -742,25 +992,7 @@ export class PrintModal extends Modal {
 
     // the resolution (meters/pixel) to re-render the map at; null means
     //  "leave the map at its current view resolution".
-    let resolution = null;
-    if (!scaleDef.fit) {
-      // the image renders at dpiMultiplier pixels per PDF point, so the
-      //  ground distance each pixel must cover is the per-point distance
-      //  spread across those pixels.
-      const groundResolution = scaleDef.metersPerPt / dpiMultiplier;
-      // web mercator (EPSG:3857) stretches distances by latitude, so the
-      //  view resolution OL renders with is not true ground meters. Convert
-      //  the desired ground resolution into a projected one at the map
-      //  center; this also keeps the scale bar (which corrects the same
-      //  way) in agreement with the printed map.
-      const projectionFactor = getPointResolution(
-        MAP_PROJECTION,
-        1,
-        this.props.mapView.center,
-        "m"
-      );
-      resolution = groundResolution / projectionFactor;
-    }
+    const resolution = this.getResolutionForScaleDef(scaleDef);
 
     return {
       width: this.toPoints(mapElement.width, layout.units) * dpiMultiplier,
@@ -800,7 +1032,7 @@ export class PrintModal extends Modal {
             resolution: evt.target.value,
           });
         }}
-        value={this.state.resolution}
+        value={this.getScaleDef().value}
       >
         {this.getScales().map((scaleDef) => (
           // TODO: Add i18n definitions for the scales
@@ -809,6 +1041,57 @@ export class PrintModal extends Modal {
           </option>
         ))}
       </select>
+    );
+  }
+
+  /** Choose what the printed scale indicator shows.
+   *
+   *  The fixed-scale option is listed only when the current scale can carry
+   *  it -- a "fit" preset names no scale, and a scale the map's zoom limits
+   *  will not reach would be captioned with a number the print does not
+   *  honor.
+   */
+  renderScaleLineSelect(t) {
+    const modes = SCALE_LINE_MODES.filter((mode) => {
+      if (mode === SCALE_LINE_DISTANCE_SCALE) {
+        return this.canShowFixedScale();
+      }
+      return true;
+    });
+
+    return (
+      <select
+        onChange={(evt) => {
+          this.setState({
+            scaleLineMode: evt.target.value,
+          });
+        }}
+        value={this.getScaleLineMode()}
+      >
+        {modes.map((mode) => (
+          <option key={mode} value={mode}>
+            {t(`scale-line-${mode}`)}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  /** Render the scale-line row.
+   *
+   *  Dropped entirely when the deployer has turned the scale line off, so
+   *  the dialog does not offer control over something that never prints.
+   */
+  renderScaleLineRow(t) {
+    const scaleLine = this.props.store.getState().config.map.scaleLine;
+    if (!scaleLine || !scaleLine.enabled) {
+      return null;
+    }
+    return (
+      <p>
+        <label>{`${t("scale-line")}:`}</label>
+        {this.renderScaleLineSelect(t)}
+      </p>
     );
   }
 
@@ -859,10 +1142,26 @@ export class PrintModal extends Modal {
       );
     }
 
+    // a configured scale that this map cannot reach is left out of the
+    //  picker. Say so here rather than only in the console, so the person
+    //  printing knows the scale they are looking for was meant to exist.
+    let scaleWarning = false;
+    const unavailable = this.getUnavailableScales();
+    if (unavailable.length > 0) {
+      scaleWarning = (
+        <div className="info-box">
+          {`These print scales are unavailable because the map's zoom limits cannot reach them: ${unavailable.join(
+            ", "
+          )}.`}
+        </div>
+      );
+    }
+
     const mapSize = this.getPrintMap();
     return (
       <div>
         {printWarning}
+        {scaleWarning}
 
         <Translation>
           {(t) => (
@@ -885,6 +1184,7 @@ export class PrintModal extends Modal {
                 <label>{`${t("resolution")}:`}</label>
                 {this.renderResolutionSelect(t)}
               </p>
+              {this.renderScaleLineRow(t)}
               <p>
                 <label>{`${t("include-selection")}:`}</label>
                 {this.renderIncludeSelection(t)}

--- a/src/gm3/lang/en.json
+++ b/src/gm3/lang/en.json
@@ -124,5 +124,9 @@
   "yes": "Yes",
   "no": "No",
   "show-layer": "Show layer {{label}}",
-  "hide-layer": "Hide layer {{label}}"
+  "hide-layer": "Hide layer {{label}}",
+  "scale-line": "Scale line",
+  "scale-line-none": "None",
+  "scale-line-line-distance": "Line and Distance",
+  "scale-line-line-distance-scale": "Line, Distance, and Scale"
 }

--- a/src/gm3/lang/es.json
+++ b/src/gm3/lang/es.json
@@ -124,5 +124,9 @@
   "yes": "Sí",
   "no": "No",
   "show-layer": "Mostrar capa {{label}}",
-  "hide-layer": "Ocultar capa {{label}}"
+  "hide-layer": "Ocultar capa {{label}}",
+  "scale-line": "Escala gráfica",
+  "scale-line-none": "Ninguno",
+  "scale-line-line-distance": "Línea y distancia",
+  "scale-line-line-distance-scale": "Línea, distancia y escala"
 }

--- a/tests/gm3/components/printModal.test.js
+++ b/tests/gm3/components/printModal.test.js
@@ -1,0 +1,339 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Dan "Ducky" Little
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Tests for the print modal's scale handling.
+ *
+ * canRenderAtResolution is pure with respect to props, so the tests drive it
+ * on a bare prototype instance rather than mounting the component -- mounting
+ * would drag in the whole print pipeline (jsPDF, the OpenLayers map) without
+ * exercising any more of the logic under test.
+ */
+
+// jsPDF ships as untransformed ESM and is only reached through the import
+//  chain -- none of the logic under test builds a PDF.
+jest.mock("jspdf", () => ({
+  __esModule: true,
+  default: function jsPDF() {},
+}));
+
+import { PrintModal } from "gm3/components/print/printModal";
+
+// EPSG:3857 at the equator: 156543.03392804097 m/px at zoom 0, halving per
+//  zoom level. maxZoom 20 therefore floors the resolution near 0.149 m/px.
+const RESOLUTION_AT_ZOOM_20 = 156543.03392804097 / Math.pow(2, 20);
+
+/* A PrintModal bound to a view config without running the constructor. */
+const modalWith = (viewConfig, state = {}, scaleLine = { enabled: true }) => {
+  const modal = Object.create(PrintModal.prototype);
+  modal.props = {
+    mapView: { center: [0, 0] },
+    store: {
+      getState: () => ({
+        config: {
+          map: {
+            view: viewConfig,
+            scaleLine,
+          },
+        },
+      }),
+    },
+  };
+  modal.state = {
+    resolution: "fit",
+    layout: 0,
+    layouts: [
+      {
+        label: "letter-portrait",
+        units: "in",
+        elements: [{ type: "map", x: 0.5, y: 0.5, width: 7.5, height: 9 }],
+      },
+    ],
+    ...state,
+  };
+  return modal;
+};
+
+describe("canRenderAtResolution", () => {
+  test("a null resolution -- a 'fit' scale -- is always renderable", () => {
+    expect(modalWith({ maxZoom: 20 }).canRenderAtResolution(null)).toBe(true);
+    expect(modalWith({ maxZoom: 20 }).canRenderAtResolution(undefined)).toBe(true);
+  });
+
+  test("an unconfigured view constrains nothing", () => {
+    expect(modalWith(undefined).canRenderAtResolution(0.0001)).toBe(true);
+  });
+
+  test("a resolution within the zoom limits is renderable", () => {
+    // well coarser than the zoom-20 floor.
+    expect(modalWith({ maxZoom: 20 }).canRenderAtResolution(1.5)).toBe(true);
+  });
+
+  test("a resolution finer than maxZoom allows is not renderable", () => {
+    // this is the case chughes-lincoln reported on #999: maxZoom 20 with a
+    //  10 ft/in scale on offer.
+    const modal = modalWith({ maxZoom: 20 });
+    expect(modal.canRenderAtResolution(RESOLUTION_AT_ZOOM_20 / 4)).toBe(false);
+  });
+
+  test("the resolution exactly at the limit is renderable", () => {
+    const modal = modalWith({ maxZoom: 20 });
+    expect(modal.canRenderAtResolution(RESOLUTION_AT_ZOOM_20)).toBe(true);
+  });
+
+  test("a resolution coarser than minZoom allows is not renderable", () => {
+    const modal = modalWith({ minZoom: 10 });
+    const resolutionAtZoom10 = 156543.03392804097 / Math.pow(2, 10);
+    expect(modal.canRenderAtResolution(resolutionAtZoom10 * 4)).toBe(false);
+  });
+
+  test("raising maxZoom makes a previously unreachable scale reachable", () => {
+    const target = RESOLUTION_AT_ZOOM_20 / 4;
+    expect(modalWith({ maxZoom: 20 }).canRenderAtResolution(target)).toBe(false);
+    expect(modalWith({ maxZoom: 24 }).canRenderAtResolution(target)).toBe(true);
+  });
+});
+
+describe("canShowFixedScale", () => {
+  test("a 'fit' preset names no scale to caption", () => {
+    expect(modalWith({}, { resolution: "fit" }).canShowFixedScale()).toBe(false);
+    expect(modalWith({}, { resolution: "fit-highest" }).canShowFixedScale()).toBe(false);
+  });
+
+  test("a fixed scale the map can reach can be captioned", () => {
+    expect(modalWith({}, { resolution: "100ft" }).canShowFixedScale()).toBe(true);
+  });
+
+  test("a fixed scale beyond the zoom limits cannot", () => {
+    // chughes-lincoln's case on #999: maxZoom 20 with 10 ft/in on offer.
+    expect(modalWith({ maxZoom: 20 }, { resolution: "10ft" }).canShowFixedScale()).toBe(false);
+    // a coarser scale on the same map is still fine.
+    expect(modalWith({ maxZoom: 20 }, { resolution: "2000ft" }).canShowFixedScale()).toBe(true);
+  });
+
+  test("an unknown scale value cannot be captioned", () => {
+    expect(modalWith({}, { resolution: "nonsense" }).canShowFixedScale()).toBe(false);
+  });
+});
+
+describe("getScaleLineMode", () => {
+  const withMode = (mode, viewConfig, resolution) =>
+    modalWith(viewConfig, { scaleLineMode: mode, resolution });
+
+  test("passes through a mode that does not need a scale", () => {
+    expect(withMode("none", {}, "fit").getScaleLineMode()).toBe("none");
+    expect(withMode("line-distance", {}, "fit").getScaleLineMode()).toBe("line-distance");
+  });
+
+  test("keeps the scale caption when the scale is reachable", () => {
+    expect(withMode("line-distance-scale", {}, "100ft").getScaleLineMode()).toBe(
+      "line-distance-scale"
+    );
+  });
+
+  test("drops to the bar alone when the scale cannot be honored", () => {
+    expect(withMode("line-distance-scale", { maxZoom: 20 }, "10ft").getScaleLineMode()).toBe(
+      "line-distance"
+    );
+  });
+
+  test("drops to the bar alone for a 'fit' preset", () => {
+    expect(withMode("line-distance-scale", {}, "fit").getScaleLineMode()).toBe("line-distance");
+  });
+});
+
+describe("componentDidUpdate holds the scale-line picker", () => {
+  // the control must never move on its own: whatever it shows is what
+  //  prints, until the user changes it themselves.
+  const mounted = (mode, resolution) => {
+    const modal = modalWith({}, { scaleLineMode: mode, resolution });
+    modal.setState = (patch) => Object.assign(modal.state, patch);
+    return modal;
+  };
+
+  test("commits the fallback when the caption becomes unavailable", () => {
+    const modal = mounted("line-distance-scale", "fit");
+    modal.componentDidUpdate({}, {});
+    expect(modal.state.scaleLineMode).toBe("line-distance");
+  });
+
+  test("a committed choice is not undone by picking a captionable scale", () => {
+    // the regression: the user saw "Line and Distance", left it alone,
+    //  chose a fixed scale, and used to get the caption anyway.
+    const modal = mounted("line-distance-scale", "fit");
+    modal.componentDidUpdate({}, {});
+    expect(modal.state.scaleLineMode).toBe("line-distance");
+
+    modal.state.resolution = "100ft";
+    modal.componentDidUpdate({}, {});
+    expect(modal.state.scaleLineMode).toBe("line-distance");
+    expect(modal.getScaleLineMode()).toBe("line-distance");
+  });
+
+  test("leaves an available choice alone", () => {
+    const modal = mounted("line-distance-scale", "100ft");
+    modal.componentDidUpdate({}, {});
+    expect(modal.state.scaleLineMode).toBe("line-distance-scale");
+  });
+
+  test("never overrides an explicit selection that is still valid", () => {
+    const modal = mounted("none", "100ft");
+    modal.componentDidUpdate({}, {});
+    expect(modal.state.scaleLineMode).toBe("none");
+  });
+
+  test("settles, rather than looping, once committed", () => {
+    const modal = mounted("line-distance-scale", "fit");
+    modal.componentDidUpdate({}, {});
+    const settled = modal.state.scaleLineMode;
+    let writes = 0;
+    modal.setState = (patch) => {
+      writes += 1;
+      Object.assign(modal.state, patch);
+    };
+    modal.componentDidUpdate({}, {});
+    expect(writes).toBe(0);
+    expect(modal.state.scaleLineMode).toBe(settled);
+  });
+});
+
+describe("getScales", () => {
+  const labels = (modal) => modal.getScales().map((s) => s.label);
+
+  test("offers every scale when the view is unconstrained", () => {
+    const modal = modalWith({});
+    expect(modal.getScales().length).toBe(modal.getAllScales().length);
+    expect(labels(modal)).toContain("10 ft / in");
+  });
+
+  test("drops scales the zoom limits cannot reach", () => {
+    const modal = modalWith({ maxZoom: 20 });
+    const offered = labels(modal);
+    // chughes-lincoln's case: 10 ft/in is unreachable under maxZoom 20.
+    expect(offered).not.toContain("10 ft / in");
+    // the coarser engineering scales survive.
+    expect(offered).toContain("2000 ft / in");
+    expect(offered.length).toBeLessThan(modal.getAllScales().length);
+  });
+
+  test("always keeps the 'fit' presets", () => {
+    const offered = labels(modalWith({ maxZoom: 1 }));
+    expect(offered).toContain("Scale to fit");
+    expect(offered).toContain("Scale to fit (higher resolution)");
+    expect(offered).toContain("Scale to fit (highest resolution)");
+  });
+
+  test("names the dropped scales for the dialog to show", () => {
+    const modal = modalWith({ maxZoom: 20 });
+    expect(modal.getUnavailableScales()).toContain("10 ft / in");
+    expect(modal.getUnavailableScales()).not.toContain("2000 ft / in");
+  });
+
+  test("offered and unavailable scales partition the configured list", () => {
+    const modal = modalWith({ maxZoom: 20 });
+    expect(modal.getScales().length + modal.getUnavailableScales().length).toBe(
+      modal.getAllScales().length
+    );
+  });
+
+  test("nothing is unavailable on an unconstrained view", () => {
+    expect(modalWith({}).getUnavailableScales()).toEqual([]);
+  });
+
+  test("tracks the view configuration rather than caching it", () => {
+    const modal = modalWith({ maxZoom: 20 });
+    expect(labels(modal)).not.toContain("10 ft / in");
+
+    modal.props.store.getState = () => ({
+      config: { map: { view: { maxZoom: 24 }, scaleLine: { enabled: true } } },
+    });
+    expect(labels(modal)).toContain("10 ft / in");
+  });
+});
+
+describe("extent-constrained views", () => {
+  // OpenLayers caps resolution at the configured extent spread across the
+  //  viewport, so the reachability check has to use the size the print map
+  //  really mounts at. Checked against a 100x100 viewport it reads far too
+  //  permissive and lets through scales the print will silently clamp.
+  //  Regression for the review finding on #1021.
+
+  // roughly 3km across, a city-sized restriction
+  const cityExtent = [-10380000, 5615000, -10377000, 5618000];
+
+  test("a scale coarser than the extent allows is not offered", () => {
+    const modal = modalWith({ extent: cityExtent });
+    const offered = modal.getScales().map((s) => s.label);
+    // 2000 ft/in needs ~4.2 m/px; the extent across the print map's
+    //  viewport only permits ~2.3 m/px.
+    expect(offered).not.toContain("2000 ft / in");
+    // the finer engineering scales are unaffected.
+    expect(offered).toContain("10 ft / in");
+    expect(offered).toContain("100 ft / in");
+  });
+
+  test("the same scale is fine without the extent restriction", () => {
+    expect(
+      modalWith({})
+        .getScales()
+        .map((s) => s.label)
+    ).toContain("2000 ft / in");
+  });
+
+  test("a larger map element admits a coarser scale", () => {
+    // the constraint is extent/viewport, so a bigger map on the page
+    //  reaches further out.
+    const small = modalWith({ extent: cityExtent });
+    const large = modalWith(
+      { extent: cityExtent },
+      {
+        layouts: [
+          {
+            label: "wall-map",
+            units: "in",
+            elements: [{ type: "map", x: 0, y: 0, width: 30, height: 30 }],
+          },
+        ],
+      }
+    );
+    const labels = (m) => m.getScales().map((s) => s.label);
+    expect(labels(small)).not.toContain("2000 ft / in");
+    expect(labels(large)).not.toEqual(labels(small));
+  });
+});
+
+describe("getScaleDef", () => {
+  test("resolves the selected scale", () => {
+    expect(modalWith({}, { resolution: "100ft" }).getScaleDef().value).toBe("100ft");
+  });
+
+  test("falls back to 'fit' when the selection is no longer offered", () => {
+    // changing layouts or panning can drop a scale out from under the
+    //  user; the picker must not keep showing a value it no longer lists.
+    const modal = modalWith({ maxZoom: 20 }, { resolution: "10ft" });
+    expect(modal.getScales().map((s) => s.value)).not.toContain("10ft");
+    expect(modal.getScaleDef().value).toBe("fit");
+    expect(modal.canShowFixedScale()).toBe(false);
+  });
+});


### PR DESCRIPTION
@theduckylittle messed up the merges of #999 and #1000 so they landed on main. This PR is an attempt to address the follow up comments for that.

## 1. A printed scale label that isn't true

@chughes-lincoln, [#999 (Aug 13)](https://github.com/geomoose/gm3/pull/999#issuecomment-5285526341):

> Something that might be worth mentioning in the docs - if the admin has configured zoom restrictions, they need to make sure that they adjust the print to scale options so that they're compatible with their zoom restrictions.
>
> i.e. if I've set a maxZoom of 20, and I update to the geomoose version that contains this PR without changing any of the default settings, users will be able to print to 10ft/in. It will still print with a label saying 1 inch = 10 feet, but in this case the result is closer to 1 inch = 75 feet.

I've added a check to available scales that prevents the over-zoom! The user won't be able to get to options they cannot "use." This can create some odd hidden states because the user may not see something the admin configures.

The "scale label" will also only display if it actually matches the map. This does not solve the misleading scale lines issue...

## 2. Misleading scale lines

@chughes-lincoln, same comment:

> I also heard feedback about wanting to be able to export a pdf at a particular scale, while also omitting the 1 inch = 10ft label. The reason being to avoid any complaints/liability for when people take a pdf exported at a particular scale, and then print it at a different one (for example I printed something at Letter - Portrait, but the printer settings defaulted to 11x17 Portrait with Fit to printable area checked - so the 10ft scalebar was still correct because it didn't change the aspect ratio, but it was no longer 10ft/inch).

@klassenjs, [#999 (Aug 17)](https://github.com/geomoose/gm3/pull/999#issuecomment-5318685424):

> Something that says something like "the scalebar should measure exactly 1 inch when printed at the intended scale" can help with this. Using a 2D reference feature (a square somewhere or maybe even the map frame) could also show issues with aspect ratio. But I could see where people might want to just turn that off too (or say not to any particular scale).

I've deferred this to being a user choice. There is now a scale line flag that will either show:

- None. Don't display a thing
- Line and Distance. Displays `|___ 100 ft ___|` (excuse my most excellent ascii art)
- Line, Distance, and Label which will display the above plus any relevant given ratio.

Users can still do awful things but at least they have some safeguards from doing so. This also prevents us from removing a user choice that may be entirely valid. I'm thinking about maps in which the user would want, say, the 1:50 scale to be shown as it is a requirement of submitting the map.


